### PR TITLE
The Instance object for the API no longer uses all Option-Types

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -26,11 +26,11 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
 final case class Instance (
      iD: Option[Long],
-    iP: Option[String],
-    portnumber: Option[Long],
-    name: Option[String],
+     host: String,
+    portnumber: Long,
+    name: String,
     /* Component Type */
-    componentType: Option[InstanceEnums.ComponentType]
+    componentType: InstanceEnums.ComponentType
 )
 
 object InstanceEnums {


### PR DESCRIPTION
As pointed out by @bhermann , this made using the class unnecessary difficult. 