### PR TITLE
Re-implementation of the whole instance registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 project/target/
 target/
+dump.temp

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
@@ -3,4 +3,5 @@ package de.upb.cs.swt.delphi.instanceregistry
 class Configuration(  //Server configuration
                     val bindHost: String = "0.0.0.0",
                     val bindPort: Int = 8087,
+                      val recoveryFileName : String = "dump.temp",
                    ) 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
@@ -1,7 +1,9 @@
 package de.upb.cs.swt.delphi.instanceregistry
 
-class Configuration(  //Server configuration
-                    val bindHost: String = "0.0.0.0",
-                    val bindPort: Int = 8087,
-                      val recoveryFileName : String = "dump.temp",
-                   ) 
+class Configuration( ) {
+  val bindHost: String = "0.0.0.0"
+  val bindPort: Int = 8087
+  val recoveryFileName : String = "dump.temp"
+}
+
+

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
@@ -1,0 +1,24 @@
+package de.upb.cs.swt.delphi.instanceregistry
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+import scala.concurrent.ExecutionContext
+
+object Registry extends AppLogging{
+  implicit val system : ActorSystem = ActorSystem("delphi-registry")
+  implicit val materializer : ActorMaterializer = ActorMaterializer()
+  implicit val ec : ExecutionContext = system.dispatcher
+
+  val configuration = new Configuration()
+  val requestHandler = new RequestHandler(configuration)
+
+  def main(args: Array[String]): Unit = {
+    requestHandler.initialize()
+    log.info("Starting server ...")
+    Server.startServer(configuration.bindHost, configuration.bindPort)
+    log.info("Shutting down ...")
+    requestHandler.shutdown()
+    system.terminate()
+  }
+}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -1,0 +1,140 @@
+package de.upb.cs.swt.delphi.instanceregistry
+
+import de.upb.cs.swt.delphi.instanceregistry.daos.{DynamicInstanceDAO, InstanceDAO}
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
+
+import scala.util.{Failure, Success, Try}
+
+class RequestHandler (configuration: Configuration) extends AppLogging {
+
+  implicit val system = Registry.system
+
+  private val instanceDao : InstanceDAO = new DynamicInstanceDAO(configuration)
+
+  def initialize() : Unit = {
+    log.info("Initializing request handler...")
+    instanceDao.initialize()
+    //Add default ES instance
+    registerNewInstance(Instance(None, "elasticsearch://localhost", 9200, "Default ElasticSearch Instance", ComponentType.ElasticSearch))
+    log.info("Done initializing request handler.")
+  }
+
+  def shutdown() : Unit = {
+    instanceDao.shutdown()
+  }
+
+  def registerNewInstance(instance : Instance) : Try[Long] = {
+    val newID = if(instanceDao.getAllInstances().isEmpty){
+      0L
+    } else {
+      (instanceDao.getAllInstances().map(i => i.id.getOrElse(0L)) max) + 1L
+    }
+
+    log.info(s"Assigned new id $newID to registering instance with name ${instance.name}.")
+
+    val newInstance = Instance(id = Some(newID), name = instance.name, host = instance.host,
+      portNumber = instance.portNumber, componentType = instance.componentType)
+
+    instanceDao.addInstance(newInstance) match {
+      case Success(_) => Success(newID)
+      case Failure(x) => Failure(x)
+    }
+  }
+
+  def removeInstance(instanceId : Long) : Try[Unit] = {
+    if(!instanceDao.hasInstance(instanceId)){
+      Failure(new RuntimeException(s"Cannot remove instance with id $instanceId, that id is not known to the server."))
+    } else {
+      instanceDao.removeInstance(instanceId)
+    }
+  }
+
+  def getAllInstancesOfType(compType : ComponentType) : List[Instance] = {
+    instanceDao.getInstancesOfType(compType)
+  }
+
+  def getNumberOfInstances(compType : ComponentType) : Int = {
+    instanceDao.getAllInstances().count(i => i.componentType == compType)
+  }
+
+  def getMatchingInstanceOfType(compType : ComponentType ) : Try[Instance] = {
+    log.info(s"Trying to match to instance of type $compType ...")
+    getNumberOfInstances(compType) match {
+      case 0 =>
+        log.error(s"Cannot match to any instance of type $compType, no such instance present.")
+        Failure(new RuntimeException(s"Cannot match to any instance of type $compType, no instance present."))
+      case 1 =>
+        val instance : Instance = instanceDao.getInstancesOfType(compType).head
+        log.info(s"Only one instance of that type present, matching to instance with id ${instance.id.get}.")
+        Success(instance)
+      case x =>
+        log.info(s"Found $x instances of type $compType.")
+
+        //First try: Match to instance with most consecutive positive matching results
+        var maxConsecutivePositiveResults = 0
+        var instanceToMatch : Instance = null
+
+        for(instance <- instanceDao.getInstancesOfType(compType)){
+          if(countConsecutivePositiveMatchingResults(instance.id.get) > maxConsecutivePositiveResults){
+            maxConsecutivePositiveResults = countConsecutivePositiveMatchingResults(instance.id.get)
+            instanceToMatch = instance
+          }
+        }
+
+        if(instanceToMatch != null){
+          log.info(s"Matching to instance with id ${instanceToMatch.id}, as it has $maxConsecutivePositiveResults positive results in a row.")
+          Success(instanceToMatch)
+        } else {
+          //Second try: Match to instance with most positive matching results
+          var maxPositiveResults = 0
+
+          for(instance <- instanceDao.getInstancesOfType(compType)){
+            val noOfPositiveResults : Int = instanceDao.getMatchingResultsFor(instance.id.get).get.count(i => i)
+            if( noOfPositiveResults > maxPositiveResults){
+              maxPositiveResults = noOfPositiveResults
+              instanceToMatch = instance
+            }
+          }
+
+          if(instanceToMatch != null){
+            log.info(s"Matching to instance with id ${instanceToMatch.id}, as it has $maxPositiveResults positive results.")
+            Success(instanceToMatch)
+          } else {
+            //All instances are equally good (or bad), match to any of them
+            instanceToMatch = instanceDao.getInstancesOfType(compType).head
+            log.info(s"Matching to instance with id ${instanceToMatch.id}, no differences between instances have been found.")
+            Success(instanceToMatch)
+          }
+        }
+    }
+
+  }
+
+  def applyMatchingResult(id : Long, result : Boolean) : Try[Unit] = {
+    if(!instanceDao.hasInstance(id)){
+      Failure(new RuntimeException(s"Cannot apply matching result to instance with id $id, that id is not known to the server"))
+    } else {
+      instanceDao.addMatchingResult(id, result)
+    }
+  }
+
+  private def countConsecutivePositiveMatchingResults(id : Long) : Int = {
+    if(!instanceDao.hasInstance(id) || instanceDao.getMatchingResultsFor(id).get.isEmpty){
+      0
+    } else {
+      val matchingResults = instanceDao.getMatchingResultsFor(id).get
+      var count = 0
+
+      for (index <- matchingResults.size to 1){
+        if(matchingResults(index - 1)){
+          count += 1
+        } else {
+          return count
+        }
+      }
+      count
+    }
+
+  }
+}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Server.scala
@@ -31,7 +31,7 @@ object Server extends HttpApp with JsonSupport with AppLogging {
       path("deregister") { deleteInstance() } ~
       path("instances" ) { fetchInstancesOfType() } ~
       path("numberOfInstances" ) { numberOfInstances() } ~
-      path("matchingInstance" ) { getMatchingInstance()} ~
+      path("matchingInstance" ) { matchingInstance()} ~
       path("matchingResult" ) {matchInstance()}
 
 
@@ -99,7 +99,7 @@ object Server extends HttpApp with JsonSupport with AppLogging {
     }
   }
 
-  def getMatchingInstance() : server.Route = parameters('ComponentType.as[String]){ compTypeString =>
+  def matchingInstance() : server.Route = parameters('ComponentType.as[String]){ compTypeString =>
     get{
       log.debug(s"GET /matchingInstance?ComponentType=$compTypeString has been called")
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -1,0 +1,79 @@
+package de.upb.cs.swt.delphi.instanceregistry.daos
+
+import akka.actor.ActorSystem
+import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Server}
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
+
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Implementation of the instance data access object that keeps its data in memory
+  * instead of using a persistent storage.
+  */
+class DynamicInstanceDAO extends InstanceDAO with AppLogging {
+
+  private val instances : mutable.Set[Instance] = new mutable.HashSet[Instance]()
+  implicit val system : ActorSystem = Server.system
+
+  override def addInstance(instance: Instance): Try[Unit] = {
+    //Verify ID is present in instance
+    if(instance.id.isEmpty){
+      val msg = s"Cannot add instance ${instance.name}, id is empty!"
+      log.warning(msg)
+      Failure(new RuntimeException(msg))
+    } else {
+      //Verify id is not already present in instances!
+      if(!hasInstance(instance.id.get)){
+        instances.add(instance)
+        Success(log.info(s"Added instance ${instance.name} with id ${instance.id} to database."))
+      } else {
+        val msg = s"Cannot add instance ${instance.name}, id ${instance.id} already present."
+        log.warning(msg)
+        Failure(new RuntimeException(msg))
+      }
+    }
+  }
+
+  override def hasInstance(id: Long): Boolean = {
+    //addInstance verifies that id : Option[Long] is not empty, so can apply .get here!
+    val query = instances filter {i => i.id.get == id}
+    query.nonEmpty
+  }
+
+  override def removeInstance(id: Long): Try[Unit] = {
+    if(hasInstance(id)){
+      //AddInstance verifies that id is always present, hasInstance verifies that find will return an instance
+      instances.remove(instances.find(i => i.id.get == id).get)
+      Success(log.info(s"Successfully removed instance with id $id."))
+    } else {
+      val msg = s"Cannot remove instance with id $id, that id is not present."
+      log.warning(msg)
+      Failure(new RuntimeException(msg))
+    }
+  }
+
+  override def getInstance(id: Long): Option[Instance] = {
+    if(hasInstance(id)) {
+      val query = instances filter {i => i.id.get == id}
+      val instance  = query.iterator.next()
+      Some(instance)
+    } else {
+      None
+    }
+  }
+
+  override def getInstancesOfType(componentType: ComponentType): List[Instance] = {
+    List() ++ instances filter {i => i.componentType == componentType}
+  }
+
+  override def getAllInstances(): List[Instance] = {
+    List() ++ instances
+  }
+
+  override def clearAll() : Unit = {
+    instances.clear()
+  }
+
+}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -4,7 +4,7 @@ import java.io.{File, IOException, PrintWriter}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Configuration, Registry, Server}
+import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Configuration, Registry}
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.{Instance, JsonSupport}
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
 
@@ -12,7 +12,6 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 import scala.io.Source
 
@@ -85,7 +84,7 @@ class DynamicInstanceDAO (configuration : Configuration) extends InstanceDAO wit
     List() ++ instances filter {i => i.componentType == componentType}
   }
 
-  override def getAllInstances(): List[Instance] = {
+  override def allInstances(): List[Instance] = {
     List() ++ instances
   }
 
@@ -141,7 +140,7 @@ class DynamicInstanceDAO (configuration : Configuration) extends InstanceDAO wit
   private[daos] def dumpToRecoveryFile() : Unit = {
     log.debug(s"Dumping data to recovery file ${configuration.recoveryFileName} ...")
     val writer = new PrintWriter(new File(configuration.recoveryFileName))
-    writer.write(getAllInstances().toJson(listFormat(instanceFormat)).toString())
+    writer.write(allInstances().toJson(listFormat(instanceFormat)).toString())
     writer.flush()
     writer.close()
     log.debug(s"Successfully wrote to recovery file.")

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -70,4 +70,14 @@ trait InstanceDAO {
     */
   def getMatchingResultsFor(id: Long) : Try[List[Boolean]]
 
+  /**
+    * Initializes the DAO
+    */
+  def initialize() : Unit
+
+  /**
+    * Shuts the DAO down
+    */
+  def shutdown(): Unit
+
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -56,4 +56,18 @@ trait InstanceDAO {
     */
   def removeAll() : Unit
 
+  /**
+    * Add a matching result for the specified instance
+    * @param id Id of the instance to post a result for
+    * @param matchingSuccessful Boolean indicating whether the matching was successful
+    */
+  def addMatchingResult(id: Long, matchingSuccessful : Boolean) : Try[Unit]
+
+  /**
+    * Gets the list of matching results for the instance with the specified id
+    * @param id Id of the instance
+    * @return List of boolean values
+    */
+  def getMatchingResultsFor(id: Long) : Try[List[Boolean]]
+
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -49,7 +49,7 @@ trait InstanceDAO {
     * Retrieves all instances from the DAO
     * @return A list of all instances in the DAO
     */
-  def getAllInstances() : List[Instance]
+  def allInstances() : List[Instance]
 
   /**
     * Removes all instances from the DAO

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -54,6 +54,6 @@ trait InstanceDAO {
   /**
     * Removes all instances from the DAO
     */
-  def clearAll() : Unit
+  def removeAll() : Unit
 
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -1,0 +1,59 @@
+package de.upb.cs.swt.delphi.instanceregistry.daos
+
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
+
+import scala.util.Try
+
+/**
+  * An Data Access Object to access the set of registered instances
+  */
+trait InstanceDAO {
+
+  /***
+    * Add a new instance to the DAO.
+    * @param instance Instance to add (attribute 'id' must not be empty!)
+    * @return Success if id was not already present, Failure otherwise
+    */
+  def addInstance(instance : Instance) : Try[Unit]
+
+  /**
+    * Checks whether the DAO holds an instance with the specified id.
+    * @param id Id to look for
+    * @return True if id is present, false otherwise
+    */
+  def hasInstance(id: Long) : Boolean
+
+  /**
+    * Removes the instance with the given id from the DAO.
+    * @param id Id of the instance that will be removed
+    * @return Success if id was present, Failure otherwise
+    */
+  def removeInstance(id: Long) : Try[Unit]
+
+  /**
+    * Gets the instance with the specified id from the DAO
+    * @param id Id of the instance to retrieve
+    * @return Some(instance) if present, else None
+    */
+  def getInstance(id: Long) : Option[Instance]
+
+  /**
+    * Retrieves all instances of the specified ComponentType from the DAO
+    * @param componentType ComponentType to look for
+    * @return A list of instances with the specified type
+    */
+  def getInstancesOfType(componentType : ComponentType) : List[Instance]
+
+  /**
+    * Retrieves all instances from the DAO
+    * @return A list of all instances in the DAO
+    */
+  def getAllInstances() : List[Instance]
+
+  /**
+    * Removes all instances from the DAO
+    */
+  def clearAll() : Unit
+
+}

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -1,17 +1,93 @@
 package de.upb.cs.swt.delphi.instanceregistry
 
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 
-class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach{
+class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll{
 
   val handler : RequestHandler = new RequestHandler(new Configuration())
 
-  override protected def beforeEach(): Unit = {
+  private def buildInstance(id : Long) : Instance = {
+    Instance(Some(id), "https://localhost", 12345, "TestInstance", ComponentType.ElasticSearch)
+  }
 
+  override protected def beforeAll():Unit = {
+    //Delete recovery file for sure
+    handler.shutdown()
+  }
+
+  override protected def beforeEach(): Unit = {
+    handler.initialize()
+  }
+
+  "The RequestHandler" must "assign new IDs to instances regardless of their actual id" in {
+    val registerNewInstance = handler.registerNewInstance(buildInstance(Long.MaxValue))
+    assert(registerNewInstance.isSuccess)
+    assert(registerNewInstance.get != Long.MaxValue)
+
+    val registerNewInstance2 = handler.registerNewInstance(buildInstance(1L))
+    assert(registerNewInstance2.isSuccess)
+    assert(registerNewInstance2.get != 1L)
+  }
+
+  it must "be able to remove instances that have been added before" in {
+    val registerNewInstance = handler.registerNewInstance(buildInstance(-1L))
+    assert(registerNewInstance.isSuccess)
+    assert(registerNewInstance.get == 1)
+    assert(handler.removeInstance(1).isSuccess)
+  }
+
+  it must "not add two default ES instances on initializing" in {
+    assert(handler.getNumberOfInstances(ComponentType.ElasticSearch) == 1)
+    handler.initialize()
+    assert(handler.getNumberOfInstances(ComponentType.ElasticSearch) == 1)
+  }
+
+  it must "match to instance with most consecutive positive matching results" in {
+    val esInstance = handler.registerNewInstance(buildInstance(2))
+    assert(esInstance.isSuccess)
+    assert(esInstance.get == 1)
+
+    assert(handler.applyMatchingResult(0, result = false).isSuccess)
+    assert(handler.applyMatchingResult(0, result = true).isSuccess)
+    assert(handler.applyMatchingResult(0,result = true).isSuccess)
+
+    assert(handler.applyMatchingResult(1,result = true).isSuccess)
+    assert(handler.applyMatchingResult(1,result = false).isSuccess)
+
+    val matchingInstance = handler.getMatchingInstanceOfType(ComponentType.ElasticSearch)
+    assert(matchingInstance.isSuccess)
+    assert(matchingInstance.get.id.get == 0)
+
+    assert(handler.removeInstance(1L).isSuccess)
+  }
+
+  it must "match to instance with most positive matching results" in {
+    val esInstance = handler.registerNewInstance(buildInstance(2))
+    assert(esInstance.isSuccess)
+    assert(esInstance.get == 1)
+
+    assert(handler.applyMatchingResult(0, result = true).isSuccess)
+    assert(handler.applyMatchingResult(0,result = true).isSuccess)
+    assert(handler.applyMatchingResult(0, result = false).isSuccess)
+
+    assert(handler.applyMatchingResult(1,result = false).isSuccess)
+    assert(handler.applyMatchingResult(1,result = false).isSuccess)
+
+    val matchingInstance = handler.getMatchingInstanceOfType(ComponentType.ElasticSearch)
+    assert(matchingInstance.isSuccess)
+    assert(matchingInstance.get.id.get == 0)
+
+    assert(handler.removeInstance(1L).isSuccess)
+  }
+
+  it must "fail to match if no instance of type is present" in {
+    assert(handler.getMatchingInstanceOfType(ComponentType.Crawler).isFailure)
   }
 
   override protected def afterEach(): Unit = {
-
+    handler.shutdown()
   }
 
 }

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -1,0 +1,17 @@
+package de.upb.cs.swt.delphi.instanceregistry
+
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+
+class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach{
+
+  val handler : RequestHandler = new RequestHandler(new Configuration())
+
+  override protected def beforeEach(): Unit = {
+
+  }
+
+  override protected def afterEach(): Unit = {
+
+  }
+
+}

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -1,10 +1,12 @@
 package de.upb.cs.swt.delphi.instanceregistry
 
+import java.io.File
+
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
-class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll{
+class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach{
 
   val handler : RequestHandler = new RequestHandler(new Configuration())
 
@@ -12,12 +14,8 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
     Instance(Some(id), "https://localhost", 12345, "TestInstance", ComponentType.ElasticSearch)
   }
 
-  override protected def beforeAll():Unit = {
-    //Delete recovery file for sure
-    handler.shutdown()
-  }
-
   override protected def beforeEach(): Unit = {
+    new File(Registry.configuration.recoveryFileName).delete()
     handler.initialize()
   }
 

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -3,7 +3,7 @@ package de.upb.cs.swt.delphi.instanceregistry.daos
 import de.upb.cs.swt.delphi.instanceregistry.Configuration
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterEach{
 
@@ -81,6 +81,29 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
     assert(dao.getAllInstances().isEmpty)
   }
 
+  it must "have an empty list of matching results for newly added instances" in {
+    dao.addInstance(buildInstance(4))
+    assert(dao.getMatchingResultsFor(4).isSuccess)
+    assert(dao.getMatchingResultsFor(4).get.isEmpty)
+  }
+
+  it must "keep the correct order of matching results posted" in {
+    assert(dao.addMatchingResult(3, matchingSuccessful = true).isSuccess)
+    assert(dao.addMatchingResult(3, matchingSuccessful = true).isSuccess)
+    assert(dao.addMatchingResult(3, matchingSuccessful = false).isSuccess)
+
+    assert(dao.getMatchingResultsFor(3).isSuccess)
+    assert(dao.getMatchingResultsFor(3).get.head)
+    assert(dao.getMatchingResultsFor(3).get (1))
+    assert(!dao.getMatchingResultsFor(3).get (2))
+
+  }
+
+  it must "remove the matching results when the instance is removed" in {
+    assert(dao.removeInstance(3).isSuccess)
+    assert(dao.getMatchingResultsFor(3).isFailure)
+  }
+
   "The DAO" must "be able to read multiple instances from the recovery file" in {
     dao.dumpToRecoveryFile()
     dao.clearData()
@@ -111,6 +134,8 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
     assert(instance.isDefined)
     assert(instance.get.id.get == 4)
   }
+
+
 
 
   override protected def afterEach() : Unit = {

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -22,14 +22,14 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
 
   "The instance DAO" must "be able to add an get an instance with a new id" in {
     assert(dao.addInstance(buildInstance(4)).isSuccess)
-    assert(dao.getAllInstances().size == 4)
+    assert(dao.allInstances().size == 4)
     assert(dao.hasInstance(4))
     assert(dao.removeInstance(4).isSuccess)
   }
 
   it must "not allow the addition of any id twice" in {
     assert(dao.addInstance(buildInstance(3)).isFailure)
-    assert(dao.getAllInstances().size == 3)
+    assert(dao.allInstances().size == 3)
   }
 
   it must "return true on hasInstance for any present id" in {
@@ -67,7 +67,7 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
       assert(dao.removeInstance(i).isSuccess)
       assert(!dao.hasInstance(i))
     }
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
   }
 
   it must "not change the data on removing invalid IDs" in {
@@ -78,7 +78,7 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
 
   it must "remove all instance on removeAll" in {
     dao.removeAll()
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
   }
 
   it must "have an empty list of matching results for newly added instances" in {
@@ -107,29 +107,29 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
   "The DAO" must "be able to read multiple instances from the recovery file" in {
     dao.dumpToRecoveryFile()
     dao.clearData()
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
     dao.tryInitFromRecoveryFile()
-    assert(dao.getAllInstances().size == 3)
+    assert(dao.allInstances().size == 3)
   }
 
   it must "fail to load from recovery file if it is not present" in {
     dao.dumpToRecoveryFile()
-    assert(dao.getAllInstances().size == 3)
+    assert(dao.allInstances().size == 3)
     dao.deleteRecoveryFile()
     dao.clearData()
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
     dao.tryInitFromRecoveryFile()
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
   }
 
   it must "contain the correct instance data after loading from recovery file" in {
     assert(dao.addInstance(buildInstance(4)).isSuccess)
     dao.dumpToRecoveryFile()
-    assert(dao.getAllInstances().size == 4)
+    assert(dao.allInstances().size == 4)
     dao.clearData()
-    assert(dao.getAllInstances().isEmpty)
+    assert(dao.allInstances().isEmpty)
     dao.tryInitFromRecoveryFile()
-    assert(dao.getAllInstances().size == 4)
+    assert(dao.allInstances().size == 4)
     val instance = dao.getInstance(4)
     assert(instance.isDefined)
     assert(instance.get.id.get == 4)

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -1,0 +1,29 @@
+package de.upb.cs.swt.delphi.instanceregistry.daos
+
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterAll{
+
+  val dao : InstanceDAO = new DynamicInstanceDAO()
+
+  private def buildInstance(id : Int) : Instance = {
+    Instance(Some(id), "https://localhost", 12345, "TestInstance", ComponentType.Crawler)
+  }
+
+  override protected def beforeAll() : Unit = {
+    dao.clearAll()
+    for(i <- 1 to 3){
+      dao.addInstance(buildInstance(i))
+    }
+  }
+
+  "The instance DAO" must "be able to add an get an instance with a new id" in {
+    assert(dao.addInstance(buildInstance(4)).isSuccess)
+    assert(dao.getAllInstances().size == 4)
+    assert(dao.hasInstance(4))
+    assert(dao.removeInstance(4).isSuccess)
+  }
+
+}

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -1,19 +1,20 @@
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
+import de.upb.cs.swt.delphi.instanceregistry.Configuration
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 
-class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterAll{
+class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterEach{
 
-  val dao : InstanceDAO = new DynamicInstanceDAO()
+  val dao : DynamicInstanceDAO = new DynamicInstanceDAO(new Configuration())
 
   private def buildInstance(id : Int) : Instance = {
     Instance(Some(id), "https://localhost", 12345, "TestInstance", ComponentType.Crawler)
   }
 
-  override protected def beforeAll() : Unit = {
-    dao.clearAll()
+  override protected def beforeEach() : Unit = {
+    dao.deleteRecoveryFile()
     for(i <- 1 to 3){
       dao.addInstance(buildInstance(i))
     }
@@ -24,6 +25,97 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterA
     assert(dao.getAllInstances().size == 4)
     assert(dao.hasInstance(4))
     assert(dao.removeInstance(4).isSuccess)
+  }
+
+  it must "not allow the addition of any id twice" in {
+    assert(dao.addInstance(buildInstance(3)).isFailure)
+    assert(dao.getAllInstances().size == 3)
+  }
+
+  it must "return true on hasInstance for any present id" in {
+    for(i <- 1 to 3){
+      assert(dao.hasInstance(i))
+    }
+  }
+
+  it must "return false on hasInstance for any id not present" in {
+    assert(!dao.hasInstance(-1))
+    assert(!dao.hasInstance(Long.MaxValue))
+    assert(!dao.hasInstance(4))
+  }
+
+  it must "return instances with the correct id on getInstance" in {
+    for(i <- 1 to 3){
+      val instance = dao.getInstance(i)
+      assert(instance.isDefined)
+      assert(instance.get.id.isDefined)
+      assert(instance.get.id.get == i)
+    }
+  }
+
+  it must "return instance with the correct type on getInstanceOfType" in {
+    val compTypeInstances = dao.getInstancesOfType(ComponentType.Crawler)
+    assert(compTypeInstances.size == 3)
+
+    for(instance <- compTypeInstances){
+      assert(instance.componentType == ComponentType.Crawler)
+    }
+  }
+
+  it must "remove instances that are present in the DAO" in {
+    for(i <- 1 to 3){
+      assert(dao.removeInstance(i).isSuccess)
+      assert(!dao.hasInstance(i))
+    }
+    assert(dao.getAllInstances().isEmpty)
+  }
+
+  it must "not change the data on removing invalid IDs" in {
+    assert(dao.removeInstance(-1).isFailure)
+    assert(dao.removeInstance(Long.MaxValue).isFailure)
+    assert(dao.removeInstance(4).isFailure)
+  }
+
+  it must "remove all instance on removeAll" in {
+    dao.removeAll()
+    assert(dao.getAllInstances().isEmpty)
+  }
+
+  "The DAO" must "be able to read multiple instances from the recovery file" in {
+    dao.dumpToRecoveryFile()
+    dao.clearData()
+    assert(dao.getAllInstances().isEmpty)
+    dao.tryInitFromRecoveryFile()
+    assert(dao.getAllInstances().size == 3)
+  }
+
+  it must "fail to load from recovery file if it is not present" in {
+    dao.dumpToRecoveryFile()
+    assert(dao.getAllInstances().size == 3)
+    dao.deleteRecoveryFile()
+    dao.clearData()
+    assert(dao.getAllInstances().isEmpty)
+    dao.tryInitFromRecoveryFile()
+    assert(dao.getAllInstances().isEmpty)
+  }
+
+  it must "contain the correct instance data after loading from recovery file" in {
+    assert(dao.addInstance(buildInstance(4)).isSuccess)
+    dao.dumpToRecoveryFile()
+    assert(dao.getAllInstances().size == 4)
+    dao.clearData()
+    assert(dao.getAllInstances().isEmpty)
+    dao.tryInitFromRecoveryFile()
+    assert(dao.getAllInstances().size == 4)
+    val instance = dao.getInstance(4)
+    assert(instance.isDefined)
+    assert(instance.get.id.get == 4)
+  }
+
+
+  override protected def afterEach() : Unit = {
+    dao.removeAll()
+    dao.deleteRecoveryFile()
   }
 
 }


### PR DESCRIPTION
Now encapsulating data acces in a data-access-object (InstanceDAO), business logic in the RequestHandler and Http / JSON parsing in the Server. Additional logging output added. Implemented unit tests for both InstanceDAO and RequestHandler. (#9) 
The data is dumped to a recovery file that is loaded on startup if still present. (#11)