### PR TITLE
Introduced event system

### DIFF
--- a/OpenAPISpecification.yaml
+++ b/OpenAPISpecification.yaml
@@ -67,7 +67,7 @@ paths:
       operationId: deleteInstance
       parameters:
         - in: query
-          name: InstanceID
+          name: Id
           description: The ID of the instance to be deregistered.
           required: true
           type: integer
@@ -185,7 +185,7 @@ paths:
       operationId: matchInstance
       parameters:
         - in: query
-          name: InstanceID
+          name: Id
           description: The ID of the instance that the sender was matched to.
           required: true
           type: integer
@@ -202,6 +202,30 @@ paths:
           description: Invalid ID supplied
         '404':
           description: No match found
+  /eventList:
+    get:
+      tags:
+        - Basic Operations
+      summary: Gets the list of events associated to the specified instance
+      description: >-
+        This command retrieves a list of events that are associated to the instance with the specified id.
+      operationId: eventList
+      parameters:
+        - name: Id
+          in: query
+          description: Id of the instance
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: List of events for the specified instance
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Event'
+        '404':
+          description: Instance not found
   /deploy:
     post:
       tags:
@@ -272,8 +296,10 @@ paths:
         - Docker Operations
       summary: Reports the manual stop of an instances to the registry
       description: >-
-        This command informs the registry about an instance that was stopped manually, meaning not via calling /stop on the instance registry. This is only applicable to instances
-        running inside a docker container, as non-container instances would deregister themselves when stopped. 
+        This command informs the registry about an instance that was stopped
+        manually, meaning not via calling /stop on the instance registry. This
+        is only applicable to instances running inside a docker container, as
+        non-container instances would deregister themselves when stopped. 
       operationId: reportStop
       parameters:
         - in: query
@@ -470,6 +496,23 @@ paths:
         '500':
           description: Internal server error
 definitions:
+  Event:
+    type: object
+    required:
+      - eventType
+      - payload
+    properties:
+      eventType:
+        type: string
+        description: Valid types for events
+        example: NumbersChangedEvent
+        enum:
+          - NumbersChangedEvent
+          - InstanceAddedEvent
+          - InstanceRemovedEvent
+          - StateChangedEvent
+      payload:
+        type: object
   Instance:
     type: object
     required:

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 libraryDependencies += "org.parboiled" %% "parboiled" % "2.1.4"
 
 
+
 lazy val registry = (project in file(".")).
   enablePlugins(JavaAppPackaging).
   enablePlugins(DockerPlugin).

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+akka.http.server.websocket.periodic-keep-alive-max-idle = 10 seconds

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -194,7 +194,7 @@ class RequestHandler(configuration: Configuration, connection: DockerConnection)
         val normalizedHost = host.substring(1,host.length - 1)
         log.info(s"Deployed new container with id $dockerId, host $normalizedHost and port $port.")
 
-        val newInstance = Instance(Some(newId), normalizedHost, port, name.getOrElse(s"Generic $componentType"), componentType, Some(dockerId), InstanceState.Stopped)
+        val newInstance = Instance(Some(newId), normalizedHost, port, name.getOrElse(s"Generic $componentType"), componentType, Some(dockerId), InstanceState.Deploying)
         log.info(s"Registering instance $newInstance....")
 
         instanceDao.addInstance(newInstance) match {

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -7,7 +7,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import de.upb.cs.swt.delphi.instanceregistry.connection.RestClient
 import de.upb.cs.swt.delphi.instanceregistry.daos.{DynamicInstanceDAO, InstanceDAO}
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model._
-import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.{ComponentType, InstanceState, State}
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.{ComponentType, InstanceState}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
@@ -22,7 +22,7 @@ class RequestHandler (configuration: Configuration) extends AppLogging {
   private[instanceregistry] val instanceDao : InstanceDAO = new DynamicInstanceDAO(configuration)
 
   val (eventActor, eventPublisher) = Source.actorRef[RegistryEvent](0, OverflowStrategy.dropNew)
-    .toMat(Sink.asPublisher(fanout = false))(Keep.both)
+    .toMat(Sink.asPublisher(fanout = true))(Keep.both)
     .run()
 
   def initialize() : Unit = {
@@ -445,7 +445,7 @@ class RequestHandler (configuration: Configuration) extends AppLogging {
     instanceDao.getInstance(id)
   }
 
-  def instanceHasState(id: Long, state : State ) : Boolean = {
+  def instanceHasState(id: Long, state : InstanceState ) : Boolean = {
     instanceDao.getInstance(id) match {
       case Some(instance) => instance.instanceState == state
       case None => false

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -374,7 +374,7 @@ object Server extends HttpApp with InstanceJsonSupport with EventJsonSupport wit
       Flow[Message]
         .map{
           case TextMessage.Strict(msg: String) => msg
-          case _ => println("Ignored non-text message.") 
+          case _ => println("Ignored non-text message.")
         }
         .via(
           Flow.fromSinkAndSource(Sink.foreach(println), Source.fromPublisher(handler.eventPublisher)

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -36,6 +36,7 @@ object Server extends HttpApp with InstanceJsonSupport with EventJsonSupport wit
       path("numberOfInstances") { numberOfInstances() } ~
       path("matchingInstance") { matchingInstance()} ~
       path("matchingResult") { matchInstance()} ~
+      path("eventList") { eventList()} ~
       /****************DOCKER OPERATIONS****************/
       path("deploy") { deployContainer()} ~
       path("reportStart") { reportStart()} ~
@@ -187,6 +188,22 @@ object Server extends HttpApp with InstanceJsonSupport with EventJsonSupport wit
           complete{s"Matching result $matchingResult processed."}
       }
     }
+  }
+
+  /**
+    * Returns a list of registry events that are associated to the instance with the specified id. The id is passed as
+    * query argument named 'Id' (so the resulting call is /eventList?Id=42).
+    * @return Server route mapping to either 200 OK and the list of event, or the resp. error codes.
+    */
+  def eventList() : server.Route = parameters('Id.as[Long]){id =>
+      get {
+        log.debug(s"GET /eventList?Id=$id has been called")
+
+        handler.getEventList(id) match {
+          case Success(list) => complete{list}
+          case Failure(_) => complete{HttpResponse(StatusCodes.NotFound, entity = s"Id $id not found.")}
+        }
+      }
   }
 
   /**

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -110,7 +110,6 @@ object Server extends HttpApp with InstanceJsonSupport with EventJsonSupport wit
       val compType : ComponentType = ComponentType.values.find(v => v.toString == compTypeString).orNull
 
       if(compType != null) {
-        handler.eventActor ! NumbersChangedEvent(1,2,3) //TODO: Remove test call
         complete{handler.getNumberOfInstances(compType).toString()}
       } else {
         log.error(s"Failed to deserialize parameter string $compTypeString to ComponentType.")
@@ -364,8 +363,6 @@ object Server extends HttpApp with InstanceJsonSupport with EventJsonSupport wit
     }
 
   }
-
-
 
 }
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -126,7 +126,7 @@ class DynamicInstanceDAO (configuration : Configuration) extends InstanceDAO wit
   override def initialize(): Unit = {
     log.info("Initializing dynamic instance DAO...")
     clearData()
-    tryInitFromRecoveryFile()
+    //tryInitFromRecoveryFile()
     log.info("Successfully initialized.")
   }
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -5,7 +5,7 @@ import java.io.{File, IOException, PrintWriter}
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Configuration, Registry}
-import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.{Instance, JsonSupport}
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.{Instance, InstanceJsonSupport}
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.{ComponentType, InstanceState}
 
 import scala.collection.mutable
@@ -19,7 +19,7 @@ import scala.io.Source
   * Implementation of the instance data access object that keeps its data in memory
   * instead of using a persistent storage.
   */
-class DynamicInstanceDAO (configuration : Configuration) extends InstanceDAO with AppLogging with JsonSupport {
+class DynamicInstanceDAO (configuration : Configuration) extends InstanceDAO with AppLogging with InstanceJsonSupport {
 
   private val instances : mutable.Set[Instance] = new mutable.HashSet[Instance]()
   private val instanceMatchingResults : mutable.Map[Long, mutable.MutableList[Boolean]] = new mutable.HashMap[Long,mutable.MutableList[Boolean]]()

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -1,6 +1,6 @@
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
-import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.Instance
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.{Instance, RegistryEvent}
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.{ComponentType, InstanceState}
 
 import scala.util.Try
@@ -92,5 +92,20 @@ trait InstanceDAO {
     * @param state New state to set
     */
   def setStateFor(id: Long, state: InstanceState.Value) : Try[Unit]
+
+  /**
+    * Add an event to the specified instance
+    * @param id Id of the instance that the event should be added to
+    * @param event Event to add
+    * @return Success if instance is present, Failure otherwise
+    */
+  def addEventFor(id: Long, event: RegistryEvent) : Try[Unit]
+
+  /**
+    * Gets the list of events for the instance with the specified id
+    * @param id Id of the instance
+    * @return List of events if instance is present, Failure otherwise
+    */
+  def getEventsFor(id: Long) : Try[List[RegistryEvent]]
 
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -1,7 +1,7 @@
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, JsonFormat}
 
 trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
@@ -21,12 +21,45 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val eventFormat : JsonFormat[Event] = jsonFormat2(Event)
+  implicit val eventFormat : JsonFormat[Event] = new JsonFormat[Event] {
+
+    override def write(event: Event): JsValue = event match {
+      case nce: NumbersChangedEvent => numbersChangedEventFormat.write(nce)
+      case iae: InstanceAddedEvent => instanceAddedEventFormat.write(iae)
+      case unrecognized => throw new RuntimeException(s"Unexpected type for event: $unrecognized")
+    }
+
+    override def read(json: JsValue): Event = json match {
+      case known:JsObject if known.fields.contains("eventType") =>
+        known.fields("eventType") match {
+          case JsString("NumbersChangedEvent") => numbersChangedEventFormat.read(known)
+          case JsString("InstanceAddedEvent") => instanceAddedEventFormat.read(known)
+          case unknown => throw DeserializationException(s"Unknown event type $unknown while deserializing.")
+        }
+      case _ => throw DeserializationException(s"Unknown event object, no type present.")
+    }
+  }
+
+  implicit val numbersChangedEventFormat: JsonFormat[NumbersChangedEvent] = jsonFormat4(NumbersChangedEvent)
+  implicit val instanceAddedEventFormat: JsonFormat[InstanceAddedEvent] = jsonFormat2(InstanceAddedEvent)
+
 }
 
-final case class Event (
-     eventType: EventEnums.EventType,
-     additionalData: String)
+abstract class Event {
+  val eventType: EventEnums.EventType.Value
+}
+
+final case class NumbersChangedEvent (
+  noOfCrawlers: Int,
+  noOfApis: Int,
+  noOfWebApps: Int,
+  override val eventType: EventEnums.EventType.Value = EventEnums.EventType.NumbersChangedEvent
+) extends Event
+
+final case class InstanceAddedEvent (
+   instanceAdded: Instance,
+   override val eventType: EventEnums.EventType.Value = EventEnums.EventType.InstanceAddedEvent
+) extends Event
 
 object EventEnums {
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -3,7 +3,7 @@ package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, JsonFormat}
 
-trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with InstanceJsonSupport {
 
   implicit val eventTypeFormat  : JsonFormat[EventEnums.EventType] = new JsonFormat[EventEnums.EventType] {
 
@@ -26,6 +26,8 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     override def write(event: Event): JsValue = event match {
       case nce: NumbersChangedEvent => numbersChangedEventFormat.write(nce)
       case iae: InstanceAddedEvent => instanceAddedEventFormat.write(iae)
+      case ire: InstanceRemovedEvent => instanceRemovedEventFormat.write(ire)
+      case sce: StateChangedEvent => stateChangedEventFormat.write(sce)
       case unrecognized => throw new RuntimeException(s"Unexpected type for event: $unrecognized")
     }
 
@@ -34,6 +36,8 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
         known.fields("eventType") match {
           case JsString("NumbersChangedEvent") => numbersChangedEventFormat.read(known)
           case JsString("InstanceAddedEvent") => instanceAddedEventFormat.read(known)
+          case JsString("InstanceRemovedEvent") => instanceRemovedEventFormat.read(known)
+          case JsString("StateChangedEvent") => stateChangedEventFormat.read(known)
           case unknown => throw DeserializationException(s"Unknown event type $unknown while deserializing.")
         }
       case _ => throw DeserializationException(s"Unknown event object, no type present.")
@@ -42,6 +46,8 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val numbersChangedEventFormat: JsonFormat[NumbersChangedEvent] = jsonFormat4(NumbersChangedEvent)
   implicit val instanceAddedEventFormat: JsonFormat[InstanceAddedEvent] = jsonFormat2(InstanceAddedEvent)
+  implicit val instanceRemovedEventFormat: JsonFormat[InstanceRemovedEvent] = jsonFormat2(InstanceRemovedEvent)
+  implicit val stateChangedEventFormat: JsonFormat[StateChangedEvent] = jsonFormat2(StateChangedEvent)
 
 }
 
@@ -60,6 +66,17 @@ final case class InstanceAddedEvent (
    instanceAdded: Instance,
    override val eventType: EventEnums.EventType.Value = EventEnums.EventType.InstanceAddedEvent
 ) extends Event
+
+final case class InstanceRemovedEvent (
+   instanceRemoved: Instance,
+   override val eventType: EventEnums.EventType.Value = EventEnums.EventType.InstanceRemovedEvent
+) extends Event
+
+final case class StateChangedEvent (
+    instanceChanged: Instance,
+    override val eventType: EventEnums.EventType.Value = EventEnums.EventType.StateChangedEvent
+) extends Event
+
 
 object EventEnums {
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -5,12 +5,27 @@ import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.EventEnums.
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.ComponentType
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, JsonFormat}
 
+/**
+  * Trait defining the implicit JSON formats needed to work with RegistryEvents
+  */
 trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with InstanceJsonSupport {
 
+  //Custom JSON format for an EventType
   implicit val eventTypeFormat  : JsonFormat[EventType] = new JsonFormat[EventType] {
 
+    /**
+      * Custom write method for serializing an EventType
+      * @param eventType The EventType to serialize
+      * @return JsString containing the serialized value
+      */
     def write(eventType : EventType) = JsString(eventType.toString)
 
+    /**
+      * Custom read method for deserialization of an EventType
+      * @param value JsValue to deserialize (must be a JsString)
+      * @return EventType that has been read
+      * @throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
     def read(value: JsValue) : EventType = value match {
       case JsString(s) => s match {
         case "StateChangedEvent" => EventType.StateChangedEvent
@@ -23,14 +38,26 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with In
     }
   }
 
+  //Custom JSON format for an RegistryEventPayload
   implicit val registryEventPayloadFormat: JsonFormat[RegistryEventPayload] = new JsonFormat[RegistryEventPayload] {
 
+    /**
+      * Custom write method for serializing an RegistryEventPayload
+      * @param payload The payload to serialize
+      * @return JsString containing the serialized value
+      */
     def write(payload: RegistryEventPayload) : JsValue = payload match {
       case ncp: NumbersChangedPayload => numbersChangedPayloadFormat.write(ncp)
       case ip:  InstancePayload => instancePayloadFormat.write(ip)
       case _ => throw new RuntimeException("Unsupported type of payload!")
     }
 
+    /**
+      * Custom read method for deserialization of an RegistryEventPayload
+      * @param json JsValue to deserialize
+      * @return RegistryEventPayload that has been read
+      *@throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
     def read(json: JsValue): RegistryEventPayload = json match{
       case jso: JsObject => if(jso.fields.isDefinedAt("instance")){
         instancePayloadFormat.read(jso)
@@ -44,43 +71,100 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with In
 
   }
 
+  //JSON format for RegistryEvents
   implicit val eventFormat : JsonFormat[RegistryEvent] = jsonFormat2(RegistryEvent)
+
+  //JSON format for an NumbersChangedPayload
   implicit val numbersChangedPayloadFormat: JsonFormat[NumbersChangedPayload] = jsonFormat2(NumbersChangedPayload)
+
+  //JSON format for an InstancePayload
   implicit val instancePayloadFormat: JsonFormat[InstancePayload] = jsonFormat1(InstancePayload)
 
 }
 
+/**
+  * The RegistryEvent used for communicating with the management application
+  * @param eventType Type of the event
+  * @param payload Payload of the event, depends on the type
+  */
 final case class RegistryEvent (
   eventType: EventType.Value,
   payload: RegistryEventPayload
 )
 
+/**
+  * Factory object for creating different types of events
+  */
 object RegistryEventFactory {
 
+  /**
+    * Creates a new NumbersChangedEvent. Sets EventType and payload accordingly.
+    * @param componentType ComponentType which's numbers have been updated
+    * @param newNumber New number of components of the specified type
+    * @return RegistryEvent with the respective type and payload.
+    */
   def createNumbersChangedEvent(componentType: ComponentType, newNumber: Int) : RegistryEvent =
     RegistryEvent(EventType.NumbersChangedEvent, NumbersChangedPayload(componentType, newNumber))
 
+  /**
+    * Creates a new InstanceAddedEvent. Sets EventType and payload accordingly.
+    * @param instance Instance that has been added.
+    * @return RegistryEvent with the respective type and payload.
+    */
   def createInstanceAddedEvent(instance: Instance) : RegistryEvent =
     RegistryEvent(EventType.InstanceAddedEvent, InstancePayload(instance))
 
+  /**
+    * Creates a new InstanceRemovedEvent. Sets EventType and payload accordingly.
+    * @param instance Instance that has been removed.
+    * @return RegistryEvent with the respective type and payload.
+    */
   def createInstanceRemovedEvent(instance: Instance) : RegistryEvent =
     RegistryEvent(EventType.InstanceRemovedEvent, InstancePayload(instance))
 
+  /**
+    * Creates a new StateChangedEvent. Sets EventType and payload accordingly.
+    * @param instance Instance which's state was changed.
+    * @return RegistryEvent with tht respective type and payload.
+    */
   def createStateChangedEvent(instance: Instance) : RegistryEvent =
     RegistryEvent(EventType.StateChangedEvent, InstancePayload(instance))
 
 }
 
-
+/**
+  * Abstract superclass for the payload of RegistryEvents. Does not declare any members, but needs to be
+  * extended by classes that will be sent as payloads of events
+  */
 abstract class RegistryEventPayload
 
+/**
+  * The NumbersChangedPayload is sent with events of type NumbersChangedEvent. It contains the ComponentType
+  * which's number has been updated, and the new number of the respective type of components.
+  * @param componentType ComponentType which's number was updated
+  * @param newNumber New number of instances for the ComponentType
+  */
 final case class NumbersChangedPayload (componentType: ComponentType, newNumber: Int) extends RegistryEventPayload
+
+/**
+  * The InstancePayload is sent with events of type InstanceAdded- /InstanceRemoved- /StateChanged-Event. It contains an
+  * instance that was added / removed / changed.
+  * @param instance Instance that caused the event.
+  */
 final case class InstancePayload(instance: Instance) extends RegistryEventPayload
 
 
+/**
+  * Enumerations concerning Events
+  */
 object EventEnums {
 
+  //Type to use when working with component types
   type EventType = EventType.Value
+
+  /**
+    * EventType enumeration defining the valid types of events issued by the instance registry
+    */
   object EventType extends Enumeration {
     val StateChangedEvent: Value = Value("StateChangedEvent")
     val InstanceAddedEvent: Value = Value("InstanceAddedEvent")

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -1,0 +1,40 @@
+package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+
+trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+
+  implicit val eventTypeFormat  : JsonFormat[EventEnums.EventType] = new JsonFormat[EventEnums.EventType] {
+
+    def write(eventType : EventEnums.EventType) = JsString(eventType.toString)
+
+    def read(value: JsValue) : EventEnums.EventType = value match {
+      case JsString(s) => s match {
+        case "StateChangedEvent" => EventEnums.EventType.StateChangedEvent
+        case "InstanceAddedEvent" => EventEnums.EventType.InstanceAddedEvent
+        case "InstanceRemovedEvent" => EventEnums.EventType.InstanceRemovedEvent
+        case "NumbersChangedEvent" => EventEnums.EventType.NumbersChangedEvent
+        case x => throw DeserializationException(s"Unexpected string value $x for event type.")
+      }
+      case y => throw DeserializationException(s"Unexpected type $y while deserializing event type.")
+    }
+  }
+
+  implicit val eventFormat : JsonFormat[Event] = jsonFormat2(Event)
+}
+
+final case class Event (
+     eventType: EventEnums.EventType,
+     additionalData: String)
+
+object EventEnums {
+
+  type EventType = EventType.Value
+  object EventType extends Enumeration {
+    val StateChangedEvent: Value = Value("StateChangedEvent")
+    val InstanceAddedEvent: Value = Value("InstanceAddedEvent")
+    val InstanceRemovedEvent: Value = Value("InstanceRemovedEvent")
+    val NumbersChangedEvent: Value = Value("NumbersChangedEvent")
+  }
+}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -3,7 +3,7 @@ package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
 
-trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val componentTypeFormat : JsonFormat[InstanceEnums.ComponentType] = new JsonFormat[InstanceEnums.ComponentType] {
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -61,6 +61,7 @@ trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
         case "Failed" => InstanceState.Failed
         case "Paused" => InstanceState.Paused
         case "NotReachable" => InstanceState.NotReachable
+        case "Deploying" => InstanceState.Deploying
         case x => throw DeserializationException(s"Unexpected string value $x for instance state.")
       }
       case y => throw DeserializationException(s"Unexpected type $y during deserialization instance state.")
@@ -117,6 +118,7 @@ object InstanceEnums {
     * InstanceState enumeration defining the valid states for instances of delphi components
     */
   object InstanceState extends Enumeration {
+    val Deploying : Value = Value("Deploying")
     val Running : Value = Value("Running")
     val Stopped : Value = Value("Stopped")
     val Failed : Value = Value("Failed")

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -1,62 +1,107 @@
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnums.{ComponentType, InstanceState}
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
 
+/**
+  * Trait defining the implicit JSON formats needed to work with Instances
+  */
 trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
-  implicit val componentTypeFormat : JsonFormat[InstanceEnums.ComponentType] = new JsonFormat[InstanceEnums.ComponentType] {
+  //Custom JSON format for an ComponentType
+  implicit val componentTypeFormat : JsonFormat[ComponentType] = new JsonFormat[ComponentType] {
 
-    def write(compType : InstanceEnums.ComponentType) = JsString(compType.toString)
+    /**
+      * Custom write method for serializing an ComponentType
+      * @param compType The ComponentType to serialize
+      * @return JsString containing the serialized value
+      */
+    def write(compType : ComponentType) = JsString(compType.toString)
 
-    def read(value: JsValue) : InstanceEnums.ComponentType = value match {
+    /**
+      * Custom read method for deserialization of an ComponentType
+      * @param value JsValue to deserialize (must be a JsString)
+      * @return ComponentType that has been read
+      * @throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
+    def read(value: JsValue) : ComponentType = value match {
       case JsString(s) => s match {
-        case "Crawler" => InstanceEnums.ComponentType.Crawler
-        case "WebApi" => InstanceEnums.ComponentType.WebApi
-        case "WebApp" => InstanceEnums.ComponentType.WebApp
-        case "DelphiManagement" => InstanceEnums.ComponentType.DelphiManagement
-        case "ElasticSearch" => InstanceEnums.ComponentType.ElasticSearch
+        case "Crawler" => ComponentType.Crawler
+        case "WebApi" => ComponentType.WebApi
+        case "WebApp" => ComponentType.WebApp
+        case "DelphiManagement" => ComponentType.DelphiManagement
+        case "ElasticSearch" => ComponentType.ElasticSearch
         case x => throw DeserializationException(s"Unexpected string value $x for component type.")
       }
       case y => throw DeserializationException(s"Unexpected type $y during deserialization component type.")
     }
   }
 
-  implicit val stateFormat  : JsonFormat[InstanceEnums.State] = new JsonFormat[InstanceEnums.State] {
+  //Custom JSON format for an InstanceState
+  implicit val stateFormat  : JsonFormat[InstanceState] = new JsonFormat[InstanceState] {
 
-    def write(compType : InstanceEnums.State) = JsString(compType.toString)
+    /**
+      * Custom write method for serializing an InstanceState
+      * @param state The InstanceState to serialize
+      * @return JsString containing the serialized value
+      */
+    def write(state : InstanceState) = JsString(state.toString)
 
-    def read(value: JsValue) : InstanceEnums.State = value match {
+    /**
+      * Custom read method for deserialization of an InstanceState
+      * @param value JsValue to deserialize (must be a JsString)
+      * @return InstanceState that has been read
+      * @throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
+    def read(value: JsValue) : InstanceState = value match {
       case JsString(s) => s match {
-        case "Running" => InstanceEnums.InstanceState.Running
-        case "Stopped" => InstanceEnums.InstanceState.Stopped
-        case "Failed" => InstanceEnums.InstanceState.Failed
-        case "Paused" => InstanceEnums.InstanceState.Paused
-        case "NotReachable" => InstanceEnums.InstanceState.NotReachable
+        case "Running" => InstanceState.Running
+        case "Stopped" => InstanceState.Stopped
+        case "Failed" => InstanceState.Failed
+        case "Paused" => InstanceState.Paused
+        case "NotReachable" => InstanceState.NotReachable
         case x => throw DeserializationException(s"Unexpected string value $x for instance state.")
       }
       case y => throw DeserializationException(s"Unexpected type $y during deserialization instance state.")
     }
   }
 
+  //JSON format for Instances
   implicit val instanceFormat : JsonFormat[Instance] = jsonFormat7(Instance)
 }
 
+/**
+  * The instance type used for transmitting data about an instance from an to the registry
+  * @param id Id of the instance. This is an Option[Long], as an registering instance will not yet have an id.
+  * @param host Host of the instance.
+  * @param portNumber Port the instance is reachable at.
+  * @param name Name of the instance
+  * @param componentType ComponentType of the instance.
+  * @param dockerId The docker container id of the instance. This is an Option[String], as not all instance have to be docker containers.
+  * @param instanceState State of the instance
+  */
 final case class Instance (
      id: Option[Long],
      host: String,
      portNumber: Long,
      name: String,
-     componentType: InstanceEnums.ComponentType,
+     componentType: ComponentType,
      dockerId: Option[String],
-     instanceState: InstanceEnums.State
+     instanceState: InstanceState
 )
-{
-}
 
+/**
+  * Enumerations concerning instances
+  */
 object InstanceEnums {
 
+  //Type to use when working with component types
   type ComponentType = ComponentType.Value
+
+  /**
+    * ComponentType enumeration defining the valid types of delphi components
+    */
   object ComponentType extends Enumeration {
     val Crawler  : Value = Value("Crawler")
     val WebApi : Value = Value("WebApi")
@@ -65,7 +110,12 @@ object InstanceEnums {
     val ElasticSearch : Value = Value("ElasticSearch")
   }
 
-  type State = InstanceState.Value
+  //Type to use when working with instance states
+  type InstanceState = InstanceState.Value
+
+  /**
+    * InstanceState enumeration defining the valid states for instances of delphi components
+    */
   object InstanceState extends Enumeration {
     val Running : Value = Value("Running")
     val Stopped : Value = Value("Stopped")

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -18,7 +18,7 @@ trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
         case "ElasticSearch" => InstanceEnums.ComponentType.ElasticSearch
         case x => throw DeserializationException(s"Unexpected string value $x for component type.")
       }
-      case y => throw DeserializationException(s"Unexpected type $y while deserializing component type.")
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization component type.")
     }
   }
 
@@ -35,7 +35,7 @@ trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
         case "NotReachable" => InstanceEnums.InstanceState.NotReachable
         case x => throw DeserializationException(s"Unexpected string value $x for instance state.")
       }
-      case y => throw DeserializationException(s"Unexpected type $y while deserializing instance state.")
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization instance state.")
     }
   }
 

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -130,40 +130,6 @@ class DynamicInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfterE
     assert(dao.getDockerIdFor(42).get.equals("dockerId"))
   }
 
-  "The DAO" must "be able to read multiple instances from the recovery file" in {
-    dao.dumpToRecoveryFile()
-    dao.clearData()
-    assert(dao.allInstances().isEmpty)
-    dao.tryInitFromRecoveryFile()
-    assert(dao.allInstances().size == 3)
-  }
-
-  it must "fail to load from recovery file if it is not present" in {
-    dao.dumpToRecoveryFile()
-    assert(dao.allInstances().size == 3)
-    dao.deleteRecoveryFile()
-    dao.clearData()
-    assert(dao.allInstances().isEmpty)
-    dao.tryInitFromRecoveryFile()
-    assert(dao.allInstances().isEmpty)
-  }
-
-  it must "contain the correct instance data after loading from recovery file" in {
-    assert(dao.addInstance(buildInstance(4)).isSuccess)
-    dao.dumpToRecoveryFile()
-    assert(dao.allInstances().size == 4)
-    dao.clearData()
-    assert(dao.allInstances().isEmpty)
-    dao.tryInitFromRecoveryFile()
-    assert(dao.allInstances().size == 4)
-    val instance = dao.getInstance(4)
-    assert(instance.isDefined)
-    assert(instance.get.id.get == 4)
-  }
-
-
-
-
   override protected def afterEach() : Unit = {
     dao.removeAll()
     dao.deleteRecoveryFile()


### PR DESCRIPTION
**Reason for this PR**
The management application frontend must be able to inform users about certain events that may require their attention. This includes an instance changing its state, being added or being removed. Also a failure of background docker-operations should be displayed.

**Solution**
Add an endpoint that allows clients to receive a continuous stream of events from the instance registry. Put events onto the stream when they occur.

**Implementation**
On calling */events* clients can now connect to a WebSocket that will ignore any incoming data, and output events as soon as they occur. An event consists of an EventType *(NumbersChangedEvent, InstanceAddedEvent, InstanceRemovedEvent, StateChangedEvent, DockerOperationErrorEvent)* and a payload, which depends on the type.