### PR TITLE
Fixed bugs in endpoint /assignInstance

### DIFF
--- a/OpenAPISpecification.yaml
+++ b/OpenAPISpecification.yaml
@@ -644,7 +644,7 @@ paths:
           type: integer
           format: int64
         - in: query
-          name: assignedInstanceId
+          name: AssignedInstanceId
           description: The ID of the instance that should be assigned as dependency
           required: true
           type: integer

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
@@ -109,7 +109,7 @@ class ContainerCommands(connection: DockerConnection) extends JsonSupport with C
   def restart(
                containerId: String,
              )(implicit ec: ExecutionContext): Future[String] = {
-    val request = Post(buildUri(containersPath / containerId / "stop"))
+    val request = Post(buildUri(containersPath / containerId / "restart"))
     connection.sendRequest(request).flatMap { response =>
       response.status match {
         case StatusCodes.NoContent =>

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -58,6 +58,7 @@ object Server extends HttpApp
       path("stop") { stop()} ~
       path("start") { start()} ~
       path("delete") { deleteContainer()} ~
+      path("assignInstance") { assignInstance()} ~
       /****************EVENT OPERATIONS****************/
       path("events") { streamEvents()}
 
@@ -484,7 +485,7 @@ object Server extends HttpApp
     * call is /assignInstance?Id=42&assignedInstanceId=43). Will update the dependency in DB and than restart the container.
     * @return Server route that either maps to 202 ACCEPTED or the respective error codes
     */
-  def assignInstance() : server.Route = parameters('Id.as[Long], 'assignedInstanceId.as[Long]) { (id, assignedInstanceId) =>
+  def assignInstance() : server.Route = parameters('Id.as[Long], 'AssignedInstanceId.as[Long]) { (id, assignedInstanceId) =>
     post {
       log.debug(s"POST /assignInstance?Id=$id&assignedInstanceId=$assignedInstanceId has been called")
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -66,7 +66,7 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with In
     def read(json: JsValue): RegistryEventPayload = json match{
       case jso: JsObject => if(jso.fields.isDefinedAt("instance")){
         instancePayloadFormat.read(jso)
-      } else if(jso.fields.isDefinedAt("noOfCrawlers")){
+      } else if(jso.fields.isDefinedAt("newNumber")){
         numbersChangedPayloadFormat.read(jso)
       } else if(jso.fields.isDefinedAt("errorMessage")) {
         dockerOperationErrorPayloadFormat.read(jso)


### PR DESCRIPTION
**Reason for this PR**
We found two bugs in the context of testing the /assignInstance endpoint
- The ```restart``` docker command was not restarting the container, but only stopping it (#45 )
- The query parameter ```assignedInstanceId```, unlike all other parameters, starts with a lowercase letter (#44)

Also there was a bug in the de-serialization of RegistryEvents, which only occurred when the same code was used in the Delphi-Management project by @janniclas . Nevertheless it is also present in the implementation of the registry. (#43)

**Solutions**
The bugs have been identified and fixed in this PR. The reason for the ```restart``` command not working was a copy-/paste-error.