### PR TITLE
Implemented endpoints to retrieve docker logs

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,1 +1,3 @@
+akka.http.client.idle-timeout = infinite
+akka.http.host-connection-pool.idle-timeout = infinite
 akka.http.server.websocket.periodic-keep-alive-max-idle = 10 seconds


### PR DESCRIPTION
**Reason for this PR**
Users want to be able to retrieve the logging output of instances (both *stdout* and *stderr* channel). Therefore an endpoint is needed, that returns the current logging output from both of these channels for a specified instance id. 
Also the Delphi management application will want to continuously stream logging output from instances, to emulate a *Terminal* window inside the browser. This requires the registry to provide a streaming endpoint for logs.

**Changes in this PR**
- Add endpoint ```/logs``` with required parameter ```Id: Long``` and optional parameter ```StdErr: Boolean```, which immediately returns all logging output from the container with the specified id
- Add endpoint ```/attach``` with same parameters as above. Requires a WebSocket request and streams the logs to the caller while container is running.
- Addresses #47 

**NOTE**
I did not add documentation for these two endpoints to the swagger specification, because the api was changed and is currently being refactored by @24santoshr as part of #57 . The documentation will be added, and the URLs for both endpoints will be harmonized with the new api *after* it is fully implemented.