### PR TITLE
Renamed docker host environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Before you can start the application, you have to make sure your configuration f
 |```maxIndividualIpReq``` | ```Int``` | ```200``` | Maximum number of requests that are allowed to be executed during the current refresh period for one specific origin ip.|
 |```ipLogRefreshRate``` | ```FiniteDuration``` | ```2.minutes``` | Duration of the log refresh period.|
 
-By default, Docker is expected to be reachable at *http://localhost:9095*, but you can override this setting by specifying the docker host URI in the environment variable *DOCKER_HOST*.
+By default, Docker is expected to be reachable at *http://localhost:9095*, but you can override this setting by specifying the docker host URI in the environment variable *DELPHI_DOCKER_HOST*.
 To change the port of your http docker API to 9095, execute
 ```
 edit /lib/systemd/system/docker.service

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
@@ -14,7 +14,7 @@ object DockerConnection {
   def fromEnvironment()(implicit system: ActorSystem, materializer: Materializer): DockerConnection = {
     def env(key: String): Option[String] = sys.env.get(key).filter(_.nonEmpty)
 
-    val host = env("DOCKER_HOST").getOrElse {
+    val host = env("DELPHI_DOCKER_HOST").getOrElse {
       "http://localhost:9095"
     }
     DockerHttpConnection(host)


### PR DESCRIPTION
**Reason for this PR**
While testing the registry setup for OSX we found that the environment variable name we use to define the docker host URL (```DOCKER_HOST```) is used by other applications as well and causes name-clashes. See #83 for more information.

**Changes in this PR**
- Changed the environment variable name from ```DOCKER_HOST``` to ```DELPHI_DOCKER_HOST```.