### PR TITLE
Trying to stop a paused instance now yields 400 Bad Request

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -504,7 +504,7 @@ class RequestHandler(configuration: Configuration, instanceDao: InstanceDAO, con
         handleDeregister(id)
         OperationResult.Ok
       }
-    } else {
+    } else if(instanceDao.getInstance(id).get.instanceState != InstanceState.Paused){
       log.info(s"Handling /stop for instance with id $id...")
 
       val instance = instanceDao.getInstance(id).get
@@ -531,6 +531,9 @@ class RequestHandler(configuration: Configuration, instanceDao: InstanceDAO, con
       }
 
       OperationResult.Ok
+    } else {
+      log.warning(s"Cannot stop paused docker container for instance with id $id")
+      OperationResult.InvalidStateForOperation
     }
   }
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -470,6 +470,9 @@ class Server (handler: RequestHandler) extends HttpApp
           case handler.OperationResult.InvalidTypeForOperation =>
             log.warning(s"Cannot stop id $id, this component type cannot be stopped.")
             complete{HttpResponse(StatusCodes.BadRequest, entity = s"Cannot stop instance of this type.")}
+          case handler.OperationResult.InvalidStateForOperation =>
+            log.warning(s"Cannot stop id $id, the associated container is paused.")
+            complete{HttpResponse(StatusCodes.BadRequest, entity = s"Cannot stop instance while it is paused.")}
           case handler.OperationResult.Ok =>
             complete{HttpResponse(StatusCodes.Accepted, entity = "Operation accepted.")}
           case r =>


### PR DESCRIPTION
**Reason for this PR**
Currently it is possible to execute a ```/stop``` command while an instance is paused. This operation is not actually allowed by Docker. See #87 for details.

**Changes in this PR**
- Trying to stop a paused instance now yields 400 Bad Request and the corresponding error message