### PR TITLE
Added additional configuration steps for macOS to README

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
@@ -32,6 +32,7 @@ class Configuration( ) {
   val maxLabelLength: Int = 50
 
   val dockerOperationTimeout: Timeout = Timeout(20 seconds)
+  val defaultDockerUri: String = "http://localhost:9095"
 
   val jwtSecretKey: String = sys.env.getOrElse("JWT_SECRET", "changeme")
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
@@ -5,17 +5,18 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.stream.Materializer
+import de.upb.cs.swt.delphi.instanceregistry.Configuration
 
 import scala.concurrent.Future
 
 object DockerConnection {
 
 
-  def fromEnvironment()(implicit system: ActorSystem, materializer: Materializer): DockerConnection = {
+  def fromEnvironment(configuration: Configuration)(implicit system: ActorSystem, materializer: Materializer): DockerConnection = {
     def env(key: String): Option[String] = sys.env.get(key).filter(_.nonEmpty)
 
     val host = env("DELPHI_DOCKER_HOST").getOrElse {
-      "http://localhost:9095"
+      configuration.defaultDockerUri
     }
     DockerHttpConnection(host)
   }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
@@ -25,7 +25,7 @@ object Registry extends AppLogging {
     }
   }
 
-  private val requestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment())
+  private val requestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment(configuration))
 
   private val server: Server = new Server(requestHandler)
 

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -20,7 +20,7 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   val configuration: Configuration = new Configuration()
   val dao: InstanceDAO = new DynamicInstanceDAO(configuration)
-  val handler: RequestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment())
+  val handler: RequestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment(configuration))
 
   private def buildInstance(id: Long, componentType: ComponentType = ComponentType.ElasticSearch, dockerId: Option[String] = None, state: InstanceState.Value = InstanceState.Stopped, labels: List[String] = List.empty[String]): Instance = {
     Instance(Some(id), "https://localhost", 12345, "TestInstance", componentType, dockerId, state, labels, List.empty[InstanceLink], List.empty[InstanceLink])

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -47,7 +47,7 @@ class ServerTest
 
   private val configuration: Configuration = new Configuration()
   private val dao: InstanceDAO = new DynamicInstanceDAO(configuration)
-  private val requestHandler: RequestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment())
+  private val requestHandler: RequestHandler = new RequestHandler(configuration, dao, DockerConnection.fromEnvironment(configuration))
   private val server: Server = new Server(requestHandler)
 
   //JSON CONSTANTS


### PR DESCRIPTION
**Reason for this PR**
To compile and run the registry in combination with docker on macOS there are some additional steps that need be executed compared to Linux or Windows. This was found and reported by @janniclas in #84. These additional steps need to be added to the Readme file.

**Changes in this PR**
- Added additional setup and configuration information to readme
- Made the default docker URI a configuration attribute (was hardcoded in ```DockerConnection.scala```)