### PR TITLE
Fixed codestyle / duplicated code issues

### DIFF
--- a/OpenAPISpecification.yaml
+++ b/OpenAPISpecification.yaml
@@ -657,13 +657,6 @@ paths:
           required: true
           type: integer
           format: int64
-        - in: body
-          name: ErrorLog
-          description: An optional string explaining the failure
-          required: false
-          schema:
-            type: string
-            example: Something went wrong..
       responses:
         '200':
           description: Report successfully processed.

--- a/project/scalastyle-config.xml
+++ b/project/scalastyle-config.xml
@@ -1,0 +1,117 @@
+<scalastyle>
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+        <parameters>
+            <parameter name="header"><![CDATA[// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/AppLogging.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/AppLogging.scala
@@ -1,8 +1,27 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry
 
 import akka.actor.{ActorSystem, ExtendedActorSystem}
 import akka.event.{BusLogging, LoggingAdapter}
 
 trait AppLogging {
-  def log(implicit system: ActorSystem): LoggingAdapter = new BusLogging(system.eventStream, this.getClass.getName, this.getClass, system.asInstanceOf[ExtendedActorSystem].logFilter)
+  def log(implicit system: ActorSystem): LoggingAdapter = new BusLogging(
+    system.eventStream,
+    this.getClass.getName,
+    this.getClass,
+    system.asInstanceOf[ExtendedActorSystem].logFilter)
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/AppLogging.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/AppLogging.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry
 
 import akka.util.Timeout

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Configuration.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Commands.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Commands.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Commands.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Commands.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.NotUsed
@@ -15,11 +30,10 @@ trait Commands extends AppLogging{
 
     Source.fromFuture(Unmarshal(response.entity).to[String](stringUnmarshaller, ec, mat).map { entity =>
       if (response.status == StatusCodes.InternalServerError) {
-        //println("exception")
 
-        throw new ServerErrorException(response.status, entity)
+        throw ServerErrorException(response.status, entity)
       } else {
-        throw new UnknownResponseException(response.status, entity)
+        throw UnknownResponseException(response.status, entity)
       }
     })
   }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Container.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Container.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 sealed trait ContainerId {
@@ -5,9 +20,9 @@ sealed trait ContainerId {
 }
 
 case class ContainerName(name: String) extends ContainerId {
-  override def value = name
+  override def value: String = name
 
-  override def toString = name
+  override def toString: String = name
 }
 
 case class CreateContainerResponse(Id: String, Warnings: Option[String])

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Container.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Container.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
@@ -276,19 +276,9 @@ class ContainerCommands(connection: DockerConnection) extends JsonSupport with C
     Success(streamPublisher)
   }
 
-  def commandCreate(
-            containerId: String,
-            cmd: String,
-            attachStdin: Option[Boolean],
-            attachStdout: Option[Boolean],
-            attachStderr: Option[Boolean],
-            detachKeys: Option[String],
-            privileged: Option[Boolean],
-            tty: Option[Boolean],
-            user: Option[String]
-          )(implicit ec: ExecutionContext): Future[CreateContainerResponse] =  {
-
-    val content = commandJsonRequest(cmd, attachStdin, attachStdout, attachStderr, detachKeys, privileged, tty, user)
+  def commandCreate(containerId: String, cmd: String, privileged: Option[Boolean], user: Option[String])
+                   (implicit ec: ExecutionContext): Future[CreateContainerResponse] = {
+    val content = commandJsonRequest(cmd, privileged, user)
 
     val request = Post(buildUri(containersPath / containerId / "exec"), HttpEntity(`application/json`, content))
 
@@ -297,6 +287,7 @@ class ContainerCommands(connection: DockerConnection) extends JsonSupport with C
 
       response.status match {
         case StatusCodes.Created =>
+
           Unmarshal(response).to[CreateContainerResponse]
         case StatusCodes.NotFound =>
           throw ContainerNotFoundException(containerId)

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/ContainerCommands.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
@@ -134,17 +134,9 @@ class DockerActor(connection: DockerConnection) extends Actor with ActorLogging 
           sender ! Status.Failure(ex)
       }
 
-    case RunCommandMessage(containerId, command, attachStdin, attachStdout, attachStderr, detachKeys, privileged, tty, user) =>
+    case RunCommandMessage(containerId, command, privileged, user) =>
       log.debug(s"running command in docker container..")
-      val createCommand = Try(Await.result(container.commandCreate(containerId,
-        command,
-        attachStdin,
-        attachStdout,
-        attachStderr,
-        detachKeys,
-        privileged,
-        tty,
-        user), Duration.Inf))
+      val createCommand = Try(Await.result(container.commandCreate(containerId, command, privileged, user), Duration.Inf))
 
       createCommand match {
         case Failure(ex) => sender ! Failure(ex)
@@ -201,16 +193,6 @@ object DockerActor {
 
   case class LogsMessage(containerId: String, stdErrSelected: Boolean, stream: Boolean)
 
-  case class RunCommandMessage(
-                         containerId: String,
-                         command: String,
-                         attachStdin: Option[Boolean],
-                         attachStdout: Option[Boolean],
-                         attachStderr: Option[Boolean],
-                         detachKeys: Option[String],
-                         privileged: Option[Boolean],
-                         tty: Option[Boolean],
-                         user: Option[String]
-                       )
+  case class RunCommandMessage(containerId: String, command: String, privileged: Option[Boolean], user: Option[String])
 
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props, Status}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerActor.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.actor.ActorSystem

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerImage.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerImage.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Registry}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerImage.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerImage.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Exceptions.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Exceptions.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.http.scaladsl.model.StatusCode

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Exceptions.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/Exceptions.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
@@ -22,7 +22,7 @@ import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat}
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
-  implicit val ContainerStatusFormat: JsonFormat[CommandType] = new JsonFormat[ContainerStatusEnums.CommandType] {
+  implicit val containerStatusFormat: JsonFormat[CommandType] = new JsonFormat[ContainerStatusEnums.CommandType] {
 
     def write(compType: ContainerStatusEnums.CommandType) = JsString(compType.toString)
 
@@ -41,7 +41,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val ContainerResponseFormat: JsonFormat[ContainerResponseEnums.CommandType] = new JsonFormat[ContainerResponseEnums.CommandType] {
+  implicit val containerResponseFormat: JsonFormat[ContainerResponseEnums.CommandType] = new JsonFormat[ContainerResponseEnums.CommandType] {
 
     def write(compType: ContainerResponseEnums.CommandType) = JsString(compType.toString)
 
@@ -55,7 +55,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val ContainerConfigFormat: JsonFormat[ContainerConfigEnums.CommandType] = new JsonFormat[ContainerConfigEnums.CommandType] {
+  implicit val containerConfigFormat: JsonFormat[ContainerConfigEnums.CommandType] = new JsonFormat[ContainerConfigEnums.CommandType] {
 
     def write(compType: ContainerConfigEnums.CommandType) = JsString(compType.toString)
 
@@ -71,7 +71,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val NetworksFormat: JsonFormat[NetworksEnums.CommandType] = new JsonFormat[NetworksEnums.CommandType] {
+  implicit val networksFormat: JsonFormat[NetworksEnums.CommandType] = new JsonFormat[NetworksEnums.CommandType] {
 
     def write(compType: NetworksEnums.CommandType) = JsString(compType.toString)
 
@@ -83,18 +83,18 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
       case y => throw new RuntimeException(s"Unexpected type $y while deserializing")
     }
   }
-  implicit val StatusFormat: JsonFormat[ContainerStatus] = jsonFormat6(ContainerStatus)
-  implicit val ExposedPortConfigFormat :JsonFormat[EmptyExposedPortConfig] = jsonFormat0(EmptyExposedPortConfig)
-  implicit val EndpointsConfigFormat :JsonFormat[EmptyEndpointConfig] = jsonFormat0(EmptyEndpointConfig)
-  implicit val NetworkConfigFormat :JsonFormat[NetworkConfig] = jsonFormat1(NetworkConfig)
-  implicit val NetworkFormat :JsonFormat[Networks] = jsonFormat1(Networks)
+  implicit val statusFormat: JsonFormat[ContainerStatus] = jsonFormat6(ContainerStatus)
+  implicit val exposedPortConfigFormat :JsonFormat[EmptyExposedPortConfig] = jsonFormat0(EmptyExposedPortConfig)
+  implicit val endpointsConfigFormat :JsonFormat[EmptyEndpointConfig] = jsonFormat0(EmptyEndpointConfig)
+  implicit val networkConfigFormat :JsonFormat[NetworkConfig] = jsonFormat1(NetworkConfig)
+  implicit val networkFormat :JsonFormat[Networks] = jsonFormat1(Networks)
 
   //For some reason you cannot type below variables explicitly, it will result in syntax errors when marshalling..
 
   //noinspection TypeAnnotation
-  implicit val ResponseFormat = jsonFormat2(CreateContainerResponse)
+  implicit val responseFormat = jsonFormat2(CreateContainerResponse)
   //noinspection TypeAnnotation
-  implicit val ConfigFormat  = jsonFormat7(ContainerConfig)
+  implicit val configFormat  = jsonFormat7(ContainerConfig)
 }
 
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
@@ -16,12 +16,13 @@
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import de.upb.cs.swt.delphi.instanceregistry.Docker.ContainerStatusEnums.CommandType
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat}
 
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
-  implicit val ContainerStatusFormat = new JsonFormat[ContainerStatusEnums.CommandType] {
+  implicit val ContainerStatusFormat: JsonFormat[CommandType] = new JsonFormat[ContainerStatusEnums.CommandType] {
 
     def write(compType: ContainerStatusEnums.CommandType) = JsString(compType.toString)
 
@@ -40,7 +41,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val ContainerResponseFormat = new JsonFormat[ContainerResponseEnums.CommandType] {
+  implicit val ContainerResponseFormat: JsonFormat[ContainerResponseEnums.CommandType] = new JsonFormat[ContainerResponseEnums.CommandType] {
 
     def write(compType: ContainerResponseEnums.CommandType) = JsString(compType.toString)
 
@@ -54,7 +55,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val ContainerConfigFormat = new JsonFormat[ContainerConfigEnums.CommandType] {
+  implicit val ContainerConfigFormat: JsonFormat[ContainerConfigEnums.CommandType] = new JsonFormat[ContainerConfigEnums.CommandType] {
 
     def write(compType: ContainerConfigEnums.CommandType) = JsString(compType.toString)
 
@@ -70,7 +71,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val NetworksFormat = new JsonFormat[NetworksEnums.CommandType] {
+  implicit val NetworksFormat: JsonFormat[NetworksEnums.CommandType] = new JsonFormat[NetworksEnums.CommandType] {
 
     def write(compType: NetworksEnums.CommandType) = JsString(compType.toString)
 
@@ -82,13 +83,18 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
       case y => throw new RuntimeException(s"Unexpected type $y while deserializing")
     }
   }
-  implicit val StatusFormat = jsonFormat6(ContainerStatus)
+  implicit val StatusFormat: JsonFormat[ContainerStatus] = jsonFormat6(ContainerStatus)
+  implicit val ExposedPortConfigFormat :JsonFormat[EmptyExposedPortConfig] = jsonFormat0(EmptyExposedPortConfig)
+  implicit val EndpointsConfigFormat :JsonFormat[EmptyEndpointConfig] = jsonFormat0(EmptyEndpointConfig)
+  implicit val NetworkConfigFormat :JsonFormat[NetworkConfig] = jsonFormat1(NetworkConfig)
+  implicit val NetworkFormat :JsonFormat[Networks] = jsonFormat1(Networks)
+
+  //For some reason you cannot type below variables explicitly, it will result in syntax errors when marshalling..
+
+  //noinspection TypeAnnotation
   implicit val ResponseFormat = jsonFormat2(CreateContainerResponse)
-  implicit val ExposedPortConfigFormat = jsonFormat0(EmptyExposedPortConfig)
-  implicit val EndpointsConfigFormat = jsonFormat0(EmptyEndpointConfig)
-  implicit val NetworkConfigFormat = jsonFormat1(NetworkConfig)
-  implicit val ConfigFormat = jsonFormat7(ContainerConfig)
-  implicit val NetworkFormat = jsonFormat1(Networks)
+  //noinspection TypeAnnotation
+  implicit val ConfigFormat  = jsonFormat7(ContainerConfig)
 }
 
 
@@ -127,7 +133,7 @@ object ContainerConfigEnums {
     val Image: Value = Value("Image")
     val EntryPoint: Value = Value("Entrypoint")
     val Command: Value = Value("Cmd")
-    val EnvironmentVariables = Value("Env")
+    val EnvironmentVariables: Value = Value("Env")
   }
 
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/JsonSupport.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.Docker
 
 import akka.util.ByteString

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/PostDataFormatting.scala
@@ -19,22 +19,9 @@ import akka.util.ByteString
 
 object PostDataFormatting {
 
-  def commandJsonRequest(cmd: String,
-                         attachStdin: Option[Boolean],
-                         attachStdout: Option[Boolean],
-                         attachStderr: Option[Boolean],
-                         detachKeys: Option[String],
-                         privileged: Option[Boolean],
-                         tty: Option[Boolean],
-                         user: Option[String]
-                        ): ByteString ={
+  def commandJsonRequest(cmd: String, privileged: Option[Boolean], user: Option[String]): ByteString ={
     var data = s""""Cmd":["$cmd"]"""
-    if(attachStdin.isDefined) data = data.concat(s""","AttachStdin":${attachStdin.get}""")
-    if(attachStdout.isDefined) data = data.concat(s""","AttachStdout":${attachStdout.get}""")
-    if(attachStderr.isDefined) data = data.concat(s""","AttachStderr":${attachStderr.get}""")
-    if(detachKeys.isDefined) data = data.concat(s""","DetachKeys":${detachKeys.get}""")
     if(privileged.isDefined) data = data.concat(s""","Privileged":${privileged.get}""")
-    if(tty.isDefined)data = data.concat(s""","Tty":${tty.get}""")
     if(user.isDefined) data = data.concat(s""","User":${user.get}""")
 
     ByteString(

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Registry.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry
 
 import akka.actor.ActorSystem

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -405,13 +405,13 @@ class RequestHandler(configuration: Configuration, authDao: AuthDAO, instanceDao
     * @param id Id of the instance that reported failure
     * @return OperationResult indicating either success or the reason for failure (which precondition was not met)
     */
-  def handleReportFailure(id: Long, errorLog: Option[String]): OperationResult.Value = {
+  def handleReportFailure(id: Long): OperationResult.Value = {
     if (!instanceDao.hasInstance(id)) {
       OperationResult.IdUnknown
     } else if (!isInstanceDockerContainer(id)) {
       OperationResult.NoDockerContainer
     } else {
-      val instance = instanceDao.getInstance(id).get //TODO:Handle errorLog
+      val instance = instanceDao.getInstance(id).get
       instance.instanceState match {
         case InstanceState.Failed =>
           log.warning(s"Instance with id $id reported failure but state already was 'Failed'.")

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry
 
 import akka.actor._
@@ -30,7 +45,7 @@ class RequestHandler(configuration: Configuration, authDao: AuthDAO, instanceDao
 
   val authProvider: AuthProvider = new AuthProvider(authDao)
 
-  val (eventActor, eventPublisher) = Source.actorRef[RegistryEvent](10, OverflowStrategy.dropNew)
+  val (eventActor, eventPublisher) = Source.actorRef[RegistryEvent](bufferSize = 10, OverflowStrategy.dropNew)
     .toMat(Sink.asPublisher(fanout = true))(Keep.both)
     .run()
   val dockerActor: ActorRef = system.actorOf(DockerActor.props(connection))
@@ -948,8 +963,8 @@ class RequestHandler(configuration: Configuration, authDao: AuthDAO, instanceDao
   /**
     * Add user to user database
     *
-    * @param user
-    * @return
+    * @param user The user to add
+    * @return Id assigned to that user
     */
   def handleAddUser(user: DelphiUser): Try[Long] = {
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AccessToken.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AccessToken.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AccessToken.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AccessToken.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.authorization
 
 import akka.http.scaladsl.model.DateTime

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AuthProvider.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AuthProvider.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AuthProvider.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/authorization/AuthProvider.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.authorization
 
 import java.nio.charset.StandardCharsets
@@ -6,7 +21,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.DateTime
 import akka.http.scaladsl.server.directives.Credentials
 import de.upb.cs.swt.delphi.instanceregistry.authorization.AccessTokenEnums.UserType
-import de.upb.cs.swt.delphi.instanceregistry.daos.{AuthDAO, DatabaseAuthDAO}
+import de.upb.cs.swt.delphi.instanceregistry.daos.AuthDAO
 import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
 import de.upb.cs.swt.delphi.instanceregistry.{AppLogging, Registry}
 import spray.json._
@@ -19,7 +34,7 @@ class AuthProvider(authDAO: AuthDAO) extends AppLogging {
 
   def authenticateBasicJWT(credentials: Credentials) : Option[String] = {
     credentials match {
-      case p @ Credentials.Provided(userName)  => {
+      case p @ Credentials.Provided(userName)  =>
         if (getSecretForUser(userName).isEmpty) {
           None
         } else if(p.verify(getSecretForUser(userName).get, hashString)){
@@ -27,7 +42,6 @@ class AuthProvider(authDAO: AuthDAO) extends AppLogging {
         } else {
           None
         }
-      }
       case _ => None
     }
   }
@@ -49,7 +63,7 @@ class AuthProvider(authDAO: AuthDAO) extends AppLogging {
     Jwt.decodeRawAll(token, Registry.configuration.jwtSecretKey, Seq(JwtAlgorithm.HS256)) match {
       case Success((_, payload, _)) =>
         parseDelphiTokenPayload(payload) match {
-          case Success(user_type) =>
+          case Success(_) =>
             log.info(s"Successfully parsed Delphi Authorization token")
             true
           case Failure(ex) =>

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/RestClient.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/RestClient.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.connection
 
 import akka.actor.ActorSystem

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/RestClient.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/RestClient.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -588,16 +588,13 @@ class Server(handler: RequestHandler) extends HttpApp
     *
     * @return Server route that either maps to 200 OK or the respective error codes
     */
-  def reportFailure(id: Long): server.Route = parameters('ErrorLog.as[String].?) { errorLog =>
+  def reportFailure(id: Long): server.Route =  {
     authenticateOAuth2[AccessToken]("Secure Site", handler.authProvider.authenticateOAuthRequire(_, userType = UserType.Component)) { token =>
       post {
-        if (errorLog.isEmpty) {
-          log.debug(s"POST /instances/$id/reportFailure has been called")
-        } else {
-          log.debug(s"POST /instances/$id/reportFailure&ErrorLog=${errorLog.get} has been called")
-        }
 
-        handler.handleReportFailure(id, errorLog) match {
+        log.debug(s"POST /instances/$id/reportFailure has been called")
+
+        handler.handleReportFailure(id) match {
           case handler.OperationResult.IdUnknown =>
             log.warning(s"Cannot report failure for id $id, that id was not found.")
             complete {

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.connection
 
 import akka.actor.ActorSystem
@@ -43,10 +58,12 @@ class Server(handler: RequestHandler) extends HttpApp
     }
   }
 
+  // scalastyle:off method.length
+
   //Routes that map http endpoints to methods in this object
   def apiRoutes: server.Route =
 
-  /** **************BASIC OPERATIONS ****************/
+  /****************BASIC OPERATIONS ****************/
     pathPrefix("instances") {
       pathEnd {
         fetchInstancesOfType()
@@ -149,7 +166,7 @@ class Server(handler: RequestHandler) extends HttpApp
       configurationInfo()
     }
 
-
+  //scalastyle:on method.length
 
   /**
     * Registers a new instance at the registry. This endpoint is intended for instances that are not running inside
@@ -571,7 +588,7 @@ class Server(handler: RequestHandler) extends HttpApp
     *
     * @return Server route that either maps to 200 OK or the respective error codes
     */
-  def reportFailure(id: Long): server.Route = parameters('ErrorLog.as[String].?) { (errorLog) =>
+  def reportFailure(id: Long): server.Route = parameters('ErrorLog.as[String].?) { errorLog =>
     authenticateOAuth2[AccessToken]("Secure Site", handler.authProvider.authenticateOAuthRequire(_, userType = UserType.Component)) { token =>
       post {
         if (errorLog.isEmpty) {
@@ -1107,10 +1124,10 @@ class Server(handler: RequestHandler) extends HttpApp
       Flow[Message]
         .map {
           case TextMessage.Strict(msg: String) => msg
-          case _ => println("Ignored non-text message.")
+          case _ => log.info("Ignored non-text message.")
         }
         .via(
-          Flow.fromSinkAndSource(Sink.foreach(println), Source.fromPublisher(handler.eventPublisher)
+          Flow.fromSinkAndSource(Sink.foreach( _ => log.debug(_)), Source.fromPublisher(handler.eventPublisher)
             .map(event => event.toJson(eventFormat).toString))
         )
         .map { msg: String => TextMessage.Strict(msg + "\n") }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -1127,7 +1127,7 @@ class Server(handler: RequestHandler) extends HttpApp
           case _ => log.info("Ignored non-text message.")
         }
         .via(
-          Flow.fromSinkAndSource(Sink.foreach( _ => log.debug(_)), Source.fromPublisher(handler.eventPublisher)
+          Flow.fromSinkAndSource(Sink.foreach(x => log.debug(x.toString)), Source.fromPublisher(handler.eventPublisher)
             .map(event => event.toJson(eventFormat).toString))
         )
         .map { msg: String => TextMessage.Strict(msg + "\n") }
@@ -1149,11 +1149,8 @@ class Server(handler: RequestHandler) extends HttpApp
         log.info(s"Requested with Delphi-Authorization token $token")
         if(handler.authProvider.isValidDelphiToken(token)){
           log.info(s"valid delphi authorization token")
-          authenticateBasic(realm = "secure", handler.authProvider.authenticateBasicJWT) {
-            case userName =>
+          authenticateBasic(realm = "secure", handler.authProvider.authenticateBasicJWT) { userName =>
               complete(handler.authProvider.generateJwt(userName))
-            case _ =>
-              complete{HttpResponse(StatusCodes.InternalServerError, entity = s"Internal server error, unknown operation result")}
           }
         } else {
           complete{HttpResponse(StatusCodes.Unauthorized, entity = s"Not valid Delphi-authorization")}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/AuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/AuthDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/AuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/AuthDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.DelphiUser
@@ -19,15 +34,15 @@ trait AuthDAO {
 
   /**
     * Gets the user with the specified username from the DAO
-    * @param userName
-    * @return
+    * @param userName Name of the user to retrieve
+    * @return Retrieved User, or None, if name not present
     */
   def getUserWithUsername(userName: String) : Option[DelphiUser]
 
   /**
     * Checks whether the DAO holds an user with the specified username.
-    * @param userName
-    * @return
+    * @param userName Name to check
+    * @return True if name is present, false otherwise
     */
   def hasUserWithUsername(userName: String) : Boolean
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseAuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseAuthDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseAuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseAuthDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 
@@ -27,7 +42,10 @@ class DatabaseAuthDAO (configuration : Configuration) extends AuthDAO with AppLo
   implicit val ec : ExecutionContext = system.dispatcher
 
   private val users : TableQuery[Users] = TableQuery[Users]
-  private val dbAuth = Database.forURL(configuration.authDatabaseHost + configuration.authDatabaseName, driver = configuration.authDatabaseDriver, user = configuration.authDatabaseUsername, password = configuration.authDatabasePassword)
+  private val dbAuth = Database.forURL(configuration.authDatabaseHost + configuration.authDatabaseName,
+    driver = configuration.authDatabaseDriver,
+    user = configuration.authDatabaseUsername,
+    password = configuration.authDatabasePassword)
 
   override def getUserWithUsername(userName: String): Option[DelphiUser] =
   {
@@ -97,15 +115,11 @@ class DatabaseAuthDAO (configuration : Configuration) extends AuthDAO with AppLo
 
   private def dbTest(): Boolean = {
     try {
-      dbAuth.createSession.conn.isValid(5)
+      val dbTimeoutSeconds = 5
+      dbAuth.createSession.conn.isValid(dbTimeoutSeconds)
     } catch {
       case e: Throwable => throw e
     }
-  }
-
-  private def removeAllUsers(): Unit = {
-    val action = users.delete
-    dbAuth.run(action)
   }
 
   private def hashString(secret: String): String = {

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import akka.actor.ActorSystem
@@ -31,7 +46,11 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
   implicit val materializer : ActorMaterializer = ActorMaterializer()
   implicit val ec : ExecutionContext = system.dispatcher
 
-  private var db = Database.forURL(configuration.instanceDatabaseHost + configuration.instanceDatabaseName, driver = configuration.instanceDatabaseDriver, user = configuration.instanceDatabaseUsername, password = configuration.instanceDatabasePassword)
+  private var db = Database.forURL(configuration.instanceDatabaseHost + configuration.instanceDatabaseName,
+    driver = configuration.instanceDatabaseDriver,
+    user = configuration.instanceDatabaseUsername,
+    password = configuration.instanceDatabasePassword)
+
   override def addInstance(instance : Instance) : Try[Long] = {
 
     val id = 0L //Will be set by DB
@@ -44,7 +63,8 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
     val labels = getListAsString(instance.labels)
     val traefikHost = instance.traefikConfiguration.map(conf => conf.hostName)
 
-    val addFuture: Future[Long] = db.run((instances returning instances.map(_.id)) += (id, host, port, name, componentType, dockerId, instanceState, labels, traefikHost))
+    val addFuture: Future[Long] =
+      db.run((instances returning instances.map(_.id)) += (id, host, port, name, componentType, dockerId, instanceState, labels, traefikHost))
     val instanceId = Await.result(addFuture, Duration.Inf)
 
     log.info(s"Added instance ${instance.name} with id $instanceId to database.")
@@ -167,7 +187,7 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
 
 
       log.info("Initializing sql instance DAO...")
-      clearData()
+      removeAll()
       log.info("Successfully initialized.")
     } else {
       log.error("Not found any database with the provided settings.")
@@ -184,7 +204,7 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
 
   override def shutdown(): Unit = {
     log.info("Shutting down dynamic instance DAO...")
-    clearData()
+    removeAll()
     log.info("Shutdown complete.")
   }
 
@@ -225,7 +245,7 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
           val query = for { single <- instances if single.id === instance.id } yield single.labels
           val updateAction = query.update(getListAsString(labels))
 
-          println(Await.result(db.run(updateAction), Duration.Inf).toString)
+          Await.result(db.run(updateAction), Duration.Inf).toString
           Success()
         }
       }
@@ -239,7 +259,8 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
     val payload = event.payload.toJson(registryEventPayloadFormat).toString
 
     if(hasInstance(id)){
-      val addEvent: Future[Long] = db.run(instanceEvents.map(c => (c.eventType, c.payload)) returning instanceEvents.map(_.id)  += (event.eventType.toString, payload))
+      val addEvent: Future[Long] =
+        db.run(instanceEvents.map(c => (c.eventType, c.payload)) returning instanceEvents.map(_.id)  += (event.eventType.toString, payload))
       val eventId = Await.result(addEvent, Duration.Inf)
       db.run(eventMaps.map(c => (c.instanceId, c.eventId)) += (id, eventId))
 
@@ -330,14 +351,6 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
 
   private def dataToObjectInstanceLinks(eventType: Long, payload: Long, state: String): InstanceLink = {
     InstanceLink.apply(eventType, payload, getLinkStateFromString(state))
-  }
-
-
-  private[daos] def clearData() : Unit = {
-    removeAllInstances()
-    removeAllInstanceMatchingResults()
-    removeAllInstanceEvents()
-    removeAllInstanceLinks()
   }
 
   private def getComponentTypeFromString(componentType: String): ComponentType ={
@@ -485,13 +498,18 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
 
   def dbTest(): Boolean = {
     try {
-      db.createSession.conn.isValid(5)
+      val timeoutDBSeconds = 5
+      db.createSession.conn.isValid(timeoutDBSeconds)
     } catch {
       case e: Throwable => throw e
     }
   }
 
-  def setDatabaseConfiguration(databaseHost: String = "", databaseName: String = "", databaseDriver: String = "", databaseUsername: String = "", databasePassword: String = "") ={
+  def setDatabaseConfiguration(databaseHost: String = "",
+                               databaseName: String = "",
+                               databaseDriver: String = "",
+                               databaseUsername: String = "",
+                               databasePassword: String = ""): Unit = {
     db = Database.forURL(databaseHost + databaseName, driver = databaseDriver, user = databaseUsername, password = databasePassword)
     initialize()
   }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicAuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicAuthDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import java.nio.charset.StandardCharsets

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicAuthDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicAuthDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import java.io.{File, IOException, PrintWriter}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/InstanceDAO.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.{Instance, InstanceLink, RegistryEvent}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/Tables.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/Tables.scala
@@ -1,42 +1,74 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 import java.sql.Timestamp
 
 import akka.http.scaladsl.model.DateTime
 import slick.jdbc.MySQLProfile
 import slick.jdbc.MySQLProfile.api._
+import slick.lifted.ProvenShape
 import slick.sql.SqlProfile.ColumnOption.{NotNull, SqlType}
 
+object StringLengthDefinitions {
+  val EnumStringLength: Int = 50
+  val HashStringLength: Int = 65
+  val NameStringLength: Int = 100
+  val UriStringLength: Int = 255
+  val LongCompositeStringLenght: Int = 1000
+}
+
 class Instances(tag: Tag) extends Table[(Long, String, Long, String, String, Option[String], String, String, Option[String])](tag, "instances") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def host = column[String]("host", O.Length(255), NotNull)
-  def portNumber = column[Long]("portNumber", NotNull)
-  def name = column[String]("name", O.Length(100), NotNull)
-  def componentType = column[String]("componentType", O.Length(50), NotNull)
-  def dockerId = column[Option[String]]("dockerId", O.Length(255), O.Default(None))
 
-  def instanceState = column[String]("instanceState", O.Length(50), NotNull)
-  def labels = column[String]("labels", O.Length(255), NotNull)
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def host: Rep[String] = column[String]("host", O.Length(StringLengthDefinitions.UriStringLength), NotNull)
+  def portNumber: Rep[Long] = column[Long]("portNumber", NotNull)
+  def name: Rep[String] = column[String]("name", O.Length(StringLengthDefinitions.NameStringLength), NotNull)
+  def componentType: Rep[String] = column[String]("componentType", O.Length(StringLengthDefinitions.EnumStringLength), NotNull)
+  def dockerId: Rep[Option[String]] = column[Option[String]]("dockerId", O.Length(StringLengthDefinitions.UriStringLength), O.Default(None))
 
-  def traefikHostName = column[Option[String]]("traefikHostName", O.Length(255), O.Default(None))
+  def instanceState: Rep[String] = column[String]("instanceState", O.Length(StringLengthDefinitions.EnumStringLength), NotNull)
+  def labels: Rep[String] = column[String]("labels", O.Length(StringLengthDefinitions.LongCompositeStringLenght), NotNull)
 
-  def * = (id, host, portNumber, name, componentType, dockerId, instanceState, labels, traefikHostName)
+  def traefikHostName : Rep[Option[String]] = column[Option[String]]("traefikHostName", O.Length(StringLengthDefinitions.UriStringLength), O.Default(None))
+
+  // scalastyle:off method.name
+  def * :ProvenShape[(Long, String, Long, String, String, Option[String], String, String, Option[String])] =
+    (id, host, portNumber, name, componentType, dockerId, instanceState, labels, traefikHostName)
+  // scalastyle:on method.name
 }
 
 class InstanceMatchingResults(tag: Tag) extends Table[(Long, Long, Boolean)](tag, "instance_matching_results") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def instanceId = column[Long]("instanceId", NotNull)
-  def matchingSuccessful = column[Boolean]("matchingSuccessful")
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def instanceId: Rep[Long] = column[Long]("instanceId", NotNull)
+  def matchingSuccessful: Rep[Boolean] = column[Boolean]("matchingSuccessful")
 
-  def * = (id, instanceId, matchingSuccessful)
+  // scalastyle:off method.name
+  def * : ProvenShape[(Long, Long, Boolean)] = (id, instanceId, matchingSuccessful)
+  // scalastyle:on method.name
 }
 
 class InstanceEvents(tag: Tag) extends Table[(Long, String, DateTime, String)](tag, "instance_events") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def eventType = column[String]("eventType", O.Length(100), NotNull)
-  def timestamp = column[DateTime]("timestamp", SqlType("timestamp not null default CURRENT_TIMESTAMP"))
-  def payload = column[String]("payload", O.Length(1000), NotNull)
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def eventType: Rep[String] = column[String]("eventType", O.Length(StringLengthDefinitions.NameStringLength), NotNull)
+  def timestamp: Rep[DateTime] = column[DateTime]("timestamp", SqlType("timestamp not null default CURRENT_TIMESTAMP"))
+  def payload: Rep[String] = column[String]("payload", O.Length(StringLengthDefinitions.LongCompositeStringLenght), NotNull)
 
-  def * = (id, eventType, timestamp, payload)
+  // scalastyle:off method.name
+  def * : ProvenShape[(Long, String, DateTime, String)] = (id, eventType, timestamp, payload)
+  // scalastyle:on method.name
 
   implicit def dateTime : MySQLProfile.BaseColumnType[DateTime] =
     MappedColumnType.base[DateTime, Timestamp](
@@ -46,27 +78,33 @@ class InstanceEvents(tag: Tag) extends Table[(Long, String, DateTime, String)](t
 }
 
 class EventMaps(tag: Tag) extends Table[(Long, Long, Long)](tag, "event_maps") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def instanceId = column[Long]("instanceId", NotNull)
-  def eventId = column[Long]("eventId", NotNull)
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def instanceId: Rep[Long] = column[Long]("instanceId", NotNull)
+  def eventId: Rep[Long] = column[Long]("eventId", NotNull)
 
-  def * = (id, instanceId, eventId)
+  // scalastyle:off method.name
+  def * : ProvenShape[(Long, Long, Long)] = (id, instanceId, eventId)
+  // scalastyle:on method.name
 }
 
 class InstanceLinks(tag: Tag) extends Table[(Long, Long, Long, String)](tag, "instance_links") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def idFrom = column[Long]("idFrom", NotNull)
-  def idTo = column[Long]("idTo", NotNull)
-  def linkState=column[String]("linkState", O.Length(100), NotNull)
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def idFrom: Rep[Long] = column[Long]("idFrom", NotNull)
+  def idTo: Rep[Long] = column[Long]("idTo", NotNull)
+  def linkState: Rep[String] = column[String]("linkState", O.Length(StringLengthDefinitions.NameStringLength), NotNull)
 
-  def * = (id, idFrom, idTo, linkState)
+  // scalastyle:off method.name
+  def * : ProvenShape[(Long, Long, Long, String)] = (id, idFrom, idTo, linkState)
+  // scalastyle:on method.name
 }
 
 class Users(tag: Tag) extends Table[(Long, String, String, String)](tag, "users") {
-  def id = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
-  def userName = column[String]("userName", O.Length(100), NotNull)
-  def secret=column[String]("secret", O.Length(65), NotNull)
-  def userType=column[String]("userType", O.Length(50), NotNull)
+  def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc) // This is the primary key column
+  def userName: Rep[String] = column[String]("userName", O.Length(StringLengthDefinitions.NameStringLength), NotNull)
+  def secret: Rep[String] = column[String]("secret", O.Length(StringLengthDefinitions.HashStringLength), NotNull)
+  def userType: Rep[String] = column[String]("userType", O.Length(StringLengthDefinitions.EnumStringLength), NotNull)
 
-  def * = (id, userName, secret, userType)
+  // scalastyle:off method.name
+  def * : ProvenShape[(Long, String, String, String)] = (id, userName, secret, userType)
+  // scalastyle:on method.name
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/Tables.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/Tables.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/ConfigurationInfo.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/ConfigurationInfo.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/ConfigurationInfo.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/ConfigurationInfo.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/DelphiUser.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/DelphiUser.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/DelphiUser.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/DelphiUser.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Event.scala
@@ -36,6 +36,7 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with In
       */
     def write(eventType : EventType) = JsString(eventType.toString)
 
+    //scalastyle:off cyclomatic.complexity
     /**
       * Custom read method for deserialization of an EventType
       * @param value JsValue to deserialize (must be a JsString)
@@ -55,6 +56,7 @@ trait EventJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with In
       }
       case y => throw DeserializationException(s"Unexpected type $y during deserialization event type.")
     }
+    //scalastyle:on cyclomatic.complexity
   }
 
   //Custom JSON format for an RegistryEventPayload

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
@@ -137,6 +152,7 @@ object InstanceEnums {
     val Failed : Value = Value("Failed")
     val Paused : Value = Value("Paused")
     val NotReachable : Value = Value("NotReachable")
+
   }
 
 }

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/Instance.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/InstanceLink.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/InstanceLink.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model
 
 import LinkEnums.LinkState

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/InstanceLink.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/io/swagger/client/model/InstanceLink.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/IpLogActor.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/IpLogActor.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/IpLogActor.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/IpLogActor.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.requestLimiter
 
 import akka.actor.{Actor, Props}

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/RequestLimitScheduler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/RequestLimitScheduler.scala
@@ -1,16 +1,31 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.requestLimiter
 
 import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.model.{HttpResponse, StatusCode, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives.{complete, extractClientIP, onSuccess}
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
-import de.upb.cs.swt.delphi.instanceregistry.{Configuration, Registry}
+import de.upb.cs.swt.delphi.instanceregistry.Registry
 import de.upb.cs.swt.delphi.instanceregistry.Docker.JsonSupport
 import de.upb.cs.swt.delphi.instanceregistry.requestLimiter.IpLogActor.{Accepted, Reset}
 

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/RequestLimitScheduler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/requestLimiter/RequestLimitScheduler.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -143,8 +143,8 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
     assert(handler.handleReportStart(-1) == handler.OperationResult.IdUnknown)
     assert(handler.handleReportStart(id) == handler.OperationResult.NoDockerContainer)
 
-    assert(handler.handleReportFailure(-1L, None) == handler.OperationResult.IdUnknown)
-    assert(handler.handleReportFailure(id, None) == handler.OperationResult.NoDockerContainer)
+    assert(handler.handleReportFailure(-1L) == handler.OperationResult.IdUnknown)
+    assert(handler.handleReportFailure(id) == handler.OperationResult.NoDockerContainer)
 
     assert(handler.handleReportStop(-1) == handler.OperationResult.IdUnknown)
     assert(handler.handleReportStop(id) == handler.OperationResult.NoDockerContainer)
@@ -189,9 +189,9 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     val (id1, id2) = (register1.get, register2.get)
 
-    assert(handler.handleReportFailure(id1, None) == handler.OperationResult.Ok)
+    assert(handler.handleReportFailure(id1) == handler.OperationResult.Ok)
     assert(handler.getInstance(id1).get.instanceState == InstanceState.Failed)
-    assert(handler.handleReportFailure(id2, None) == handler.OperationResult.Ok)
+    assert(handler.handleReportFailure(id2) == handler.OperationResult.Ok)
     assert(handler.getInstance(id2).get.instanceState == InstanceState.Failed)
   }
 

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -288,9 +288,9 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
   }
 
   it must "not add two default ES instances on initializing" in {
-    assert(handler.getNumberOfInstances(ComponentType.ElasticSearch) == 1)
+    assert(handler.getNumberOfInstances(Some(ComponentType.ElasticSearch)) == 1)
     handler.initialize()
-    assert(handler.getNumberOfInstances(ComponentType.ElasticSearch) == 1)
+    assert(handler.getNumberOfInstances(Some(ComponentType.ElasticSearch)) == 1)
   }
 
   it must "validate preconditions before adding a label" in {

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -183,7 +183,7 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
   it must "change the state on reportFailure" in {
     val register1 = dao.addInstance(buildInstance(id = 42, dockerId  = Some("RandomDockerId"), state = InstanceState.Stopped))
     val register2 = dao.addInstance(buildInstance(id = 43, dockerId = Some("RandomDockerId2"), state = InstanceState.Running))
-    
+
     assert(register1.isSuccess)
     assert(register2.isSuccess)
 
@@ -239,15 +239,6 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
   it must "validate preconditions on handleStop" in {
     assert(handler.handleStop(Int.MaxValue) == handler.OperationResult.IdUnknown)
   }
-
-  //Below test is not applicable anymore, state change is managed in futures!
-  /*it must "change the state of the instance on handleStop" in {
-    val register1 = dao.addInstance(Instance(Some(1), "http://localhost", 8083, "MyCrawler", ComponentType.Crawler, Some("RandomDockerId"), InstanceState.Running))
-    assert(register1.isSuccess)
-
-    assert(handler.handleStop(1) == handler.OperationResult.Ok)
-    assert(handler.getInstance(1).get.instanceState == InstanceState.Stopped)
-  }*/
 
   it must "validate preconditions on handleStart" in {
     val register1 = dao.addInstance(buildInstance(1))

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry
 
 import java.io.File
@@ -11,8 +26,6 @@ import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.InstanceEnu
 import de.upb.cs.swt.delphi.instanceregistry.io.swagger.client.model.LinkEnums.LinkState
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
-import scala.concurrent.ExecutionContext
-
 class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   implicit val system : ActorSystem = ActorSystem("test_system")
@@ -23,7 +36,11 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
   val authDAO: AuthDAO = new DynamicAuthDAO(configuration)
   val handler: RequestHandler = new RequestHandler(configuration, authDAO, dao, DockerConnection.fromEnvironment(configuration))
 
-  private def buildInstance(id: Long, componentType: ComponentType = ComponentType.ElasticSearch, dockerId: Option[String] = None, state: InstanceState.Value = InstanceState.Stopped, labels: List[String] = List.empty[String]): Instance = {
+  private def buildInstance(id: Long,
+                            componentType: ComponentType = ComponentType.ElasticSearch,
+                            dockerId: Option[String] = None,
+                            state: InstanceState.Value = InstanceState.Stopped,
+                            labels: List[String] = List.empty[String]): Instance = {
     Instance(Some(id), "https://localhost", 12345, "TestInstance", componentType, dockerId, state, labels, List.empty[InstanceLink], List.empty[InstanceLink])
   }
 
@@ -365,7 +382,16 @@ class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   it must "match to instance with most consecutive positive matching results in fallback matching" in {
     val esInstance = handler.handleRegister(buildInstance(2))
-    val crawlerId = handler.handleRegister(Instance(Some(2), "foo", 42, "bar", ComponentType.Crawler, None, InstanceState.Running, List.empty[String], List.empty[InstanceLink], List.empty[InstanceLink]))
+    val crawlerId = handler.handleRegister(Instance(Some(2),
+      "foo",
+      42,
+      "bar",
+      ComponentType.Crawler,
+      None,
+      InstanceState.Running,
+      List.empty[String],
+      List.empty[InstanceLink],
+      List.empty[InstanceLink]))
 
     assert(esInstance.isSuccess)
     assert(esInstance.get == 1)

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -97,13 +97,15 @@ class ServerTest
       }
 
       //Wrong JSON syntax
-      Post("/instances/register", HttpEntity(ContentTypes.`application/json`, invalidJsonInstance.stripMargin)) ~> addAuthorization("Component") ~> server.routes ~> check {
+      Post("/instances/register", HttpEntity(ContentTypes.`application/json`, invalidJsonInstance.stripMargin)) ~>
+        addAuthorization("Component") ~> server.routes ~> check {
         assert(status === StatusCodes.BAD_REQUEST)
         responseAs[String].toLowerCase should include("failed to parse json")
       }
 
       //Missing required JSON members
-      Post("/instances/register", HttpEntity(ContentTypes.`application/json`, validJsonInstanceMissingRequiredMember.stripMargin)) ~> addAuthorization("Component") ~> server.routes ~> check {
+      Post("/instances/register", HttpEntity(ContentTypes.`application/json`, validJsonInstanceMissingRequiredMember.stripMargin)) ~>
+        addAuthorization("Component") ~> server.routes ~> check {
         assert(status === StatusCodes.BAD_REQUEST)
         responseAs[String].toLowerCase should include("could not deserialize parameter instance")
       }
@@ -404,7 +406,8 @@ class ServerTest
       val id2 = assertValidRegister(ComponentType.WebApi)
 
 
-      Post(s"/instances/$id1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": true, "SenderId" : $id2}""")) ~> addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
+      Post(s"/instances/$id1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": true, "SenderId" : $id2}""")) ~>
+        addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.OK)
         responseAs[String] shouldEqual "Matching result true processed."
       }
@@ -418,24 +421,28 @@ class ServerTest
     "not process matching result if method or parameters are invalid" in {
       //Wrong method
 
-      Get(s"/instances/0/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": true, "SenderId" : 0}""")) ~> addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
+      Get(s"/instances/0/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": true, "SenderId" : 0}""")) ~>
+        addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.METHOD_NOT_ALLOWED)
         responseAs[String] shouldEqual "HTTP method not allowed, supported methods: POST"
       }
 
       //Invalid IDs - expect 404
-      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~> addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
+      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~>
+        addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.NOT_FOUND)
       }
 
       //Wrong user type
-      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~> addAuthorization("User") ~> Route.seal(server.routes) ~> check {
+      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~>
+        addAuthorization("User") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.UNAUTHORIZED)
         responseAs[String] shouldEqual "The supplied authentication is invalid"
       }
 
       //No authorization
-      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~> Route.seal(server.routes) ~> check {
+      Post(s"/instances/1/matchingResult", HttpEntity(ContentTypes.`application/json`, s"""{ "MatchingSuccessful": false, "SenderId" : 2}""")) ~>
+        Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.UNAUTHORIZED)
         responseAs[String].toLowerCase should include("not supplied with the request")
       }
@@ -611,7 +618,8 @@ class ServerTest
 
     //Valid POST /instances/{id}/label
     "add a generic label to an instance is label and id are valid" in {
-      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Admin") ~> server.routes ~> check {
+      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Admin") ~>
+        server.routes ~> check {
         assert(status === StatusCodes.OK)
         responseAs[String] shouldEqual "Successfully added label"
       }
@@ -619,25 +627,29 @@ class ServerTest
     //Invalid POST /instances/{id}/label
     "fail to add label if id is invalid or label too long" in {
       //Unknown id - expect 404
-      Post("/instances/45/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Admin") ~> server.routes ~> check {
+      Post("/instances/45/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Admin") ~>
+        server.routes ~> check {
         assert(status === StatusCodes.NOT_FOUND)
         responseAs[String] shouldEqual "Cannot add label, id 45 not found."
       }
       //Label out of bounds - expect 400
       val tooLongLabel = "VeryVeryExtraLongLabelThatDoesNotWorkWhileAddingLabel"
       val jsonStr = tooLongLabel.toJson
-      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, s"""{ "Label": $jsonStr}""")) ~> addAuthorization("Admin") ~> server.routes ~> check {
+      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, s"""{ "Label": $jsonStr}""")) ~> addAuthorization("Admin") ~>
+        server.routes ~> check {
         assert(status === StatusCodes.BAD_REQUEST)
         responseAs[String].toLowerCase should include("exceeds character limit")
       }
       //Wrong user type
-      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Component") ~> Route.seal(server.routes) ~> check {
+      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("Component") ~>
+        Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.UNAUTHORIZED)
         responseAs[String] shouldEqual "The supplied authentication is invalid"
       }
 
       //Wrong user type
-      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("User") ~> Route.seal(server.routes) ~> check {
+      Post("/instances/0/label", HttpEntity(ContentTypes.`application/json`, """{ "Label": "Private"}""")) ~> addAuthorization("User") ~>
+        Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.UNAUTHORIZED)
         responseAs[String] shouldEqual "The supplied authentication is invalid"
       }
@@ -652,13 +664,15 @@ class ServerTest
     /** Minimal tests for docker operations **/
 
     "fail to deploy if component type is invalid" in {
-      Post("/instances/deploy", HttpEntity(ContentTypes.`application/json`, """{"ComponentType": "Car"}""")) ~> addAuthorization("Admin") ~> server.routes ~> check {
+      Post("/instances/deploy", HttpEntity(ContentTypes.`application/json`, """{"ComponentType": "Car"}""")) ~> addAuthorization("Admin") ~>
+        server.routes ~> check {
         status shouldEqual StatusCodes.BAD_REQUEST
         responseAs[String].toLowerCase should include("could not deserialize")
       }
 
       //Wrong user type
-      Post("/instances/deploy", HttpEntity(ContentTypes.`application/json`, """{"ComponentType": "Crawler"}""")) ~> addAuthorization("User") ~> server.routes ~> check {
+      Post("/instances/deploy", HttpEntity(ContentTypes.`application/json`, """{"ComponentType": "Crawler"}""")) ~> addAuthorization("User") ~>
+        server.routes ~> check {
         rejection.isInstanceOf[AuthenticationFailedRejection] shouldBe true
       }
 
@@ -702,7 +716,8 @@ class ServerTest
         responseAs[String].toLowerCase should include("not found")
       }
 
-      Post("/instances/42/assignInstance", HttpEntity(ContentTypes.`application/json`, """{ "AssignedInstanceId": 43}""")) ~> addAuthorization("Admin") ~> server.routes ~> check {
+      Post("/instances/42/assignInstance", HttpEntity(ContentTypes.`application/json`, """{ "AssignedInstanceId": 43}""")) ~>
+        addAuthorization("Admin") ~> server.routes ~> check {
         status shouldEqual StatusCodes.NOT_FOUND
         responseAs[String].toLowerCase should include("not found")
       }
@@ -765,7 +780,7 @@ class ServerTest
 
     "Requests" should {
       "throttle when limit reached" in {
-        for (i <- 1 to configuration.maxIndividualIpReq) {
+        for (_ <- 1 to configuration.maxIndividualIpReq) {
           Get(s"/instances/0/linksTo") ~> server.routes ~> check {}
         }
 
@@ -812,8 +827,8 @@ class ServerTest
       .issuedNow
       .expiresIn(5)
       .startsNow
-      .+("user_id", "Server Unit Test")
-      .+("user_type", userType)
+      . + ("user_id", "Server Unit Test")
+      . + ("user_type", userType)
 
     Jwt.encode(claim, configuration.jwtSecretKey, JwtAlgorithm.HS256)
   }

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAOTest.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import de.upb.cs.swt.delphi.instanceregistry.Configuration
@@ -72,7 +87,7 @@ class DatabaseInstanceDAOTest extends FlatSpec with Matchers with BeforeAndAfter
 
   it must "Successfully added the Instance matching result" in {
     val idOption = dao.addInstance(buildInstance(6))
-    dao.addMatchingResult(idOption.get, true)
+    dao.addMatchingResult(idOption.get, matchingSuccessful = true)
     assert(dao.getMatchingResultsFor(idOption.get).isSuccess)
   }
 

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAOTest.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -5,9 +5,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DynamicInstanceDAOTest.scala
@@ -1,3 +1,18 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package de.upb.cs.swt.delphi.instanceregistry.daos
 
 import de.upb.cs.swt.delphi.instanceregistry.Configuration


### PR DESCRIPTION
**Reason for this PR**
This PR addresses several issues:
- There are a lot of codestyle issues in the source code of the registry, and no configuration for scalastyle ( #102 )
- Some unused code is still part of our source code ( #103 )
- The code comments in the ```Server.scala``` file do not match the new API design (#106 )

**Changes in this PR**
- Added ```scalastyle-config.xml```, which has been taken form the webapi and slightly modified.
- Fixed all codestyle issues reported by IntelliJ based on the given configuration file
- Removed unsued parameter ```ErrorLog``` for ```reportFailure```
- Removed unused parameter switches for ```runCommand```
- Updated code comments in ```Server.scala```
