### PR TITLE
Trying to fix race condition for CI tests

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/Docker/DockerConnection.scala
@@ -5,14 +5,14 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.stream.Materializer
-import de.upb.cs.swt.delphi.instanceregistry.Configuration
+import de.upb.cs.swt.delphi.instanceregistry.{Configuration, Registry}
 
 import scala.concurrent.Future
 
 object DockerConnection {
 
 
-  def fromEnvironment(configuration: Configuration) (implicit system: ActorSystem, mat: Materializer): DockerConnection = {
+  def fromEnvironment(configuration: Configuration): DockerConnection = {
     DockerHttpConnection(configuration.dockerUri)
   }
 }
@@ -33,10 +33,11 @@ trait DockerConnection {
 
 }
 
-case class DockerHttpConnection(
-                                 baseUri: Uri,
-                               )(implicit val system: ActorSystem, val materializer: Materializer)
+case class DockerHttpConnection(baseUri: Uri)
   extends DockerConnection {
+  override def system: ActorSystem = Registry.system
+  override implicit def materializer: Materializer = Registry.materializer
+
   override def sendRequest(request: HttpRequest): Future[HttpResponse] = {
     Http(system).singleRequest(request)
   }

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandlerTest.scala
@@ -15,9 +15,6 @@ import scala.concurrent.ExecutionContext
 
 class RequestHandlerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
-  implicit val system : ActorSystem = ActorSystem("test_system")
-  implicit val materializer : ActorMaterializer = ActorMaterializer()
-
   val configuration: Configuration = new Configuration()
   val dao: InstanceDAO = new DynamicInstanceDAO(configuration)
   val authDAO: AuthDAO = new DynamicAuthDAO(configuration)

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -63,7 +63,7 @@ class ServerTest
 
 
   /**
-    * Before all tests: Initialize handler and wait for server binding to be ready.
+    * Before all tests: Initialize handler and wait for server binding to be ready
     */
   override def beforeAll(): Unit = {
     requestHandler.initialize()

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -74,8 +74,6 @@ class ServerTest
     */
   override def afterAll(): Unit = {
     requestHandler.shutdown()
-    //Await.ready(Registry.system.terminate(), Duration.Inf)
-    //Await.ready(system.terminate(), Duration.Inf)
   }
 
   "The Server" should {

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -63,7 +63,7 @@ class ServerTest
 
 
   /**
-    * Before all tests: Initialize handler and wait for server binding to be ready
+    * Before all tests: Initialize handler and wait for server binding to be ready.
     */
   override def beforeAll(): Unit = {
     requestHandler.initialize()

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -74,8 +74,8 @@ class ServerTest
     */
   override def afterAll(): Unit = {
     requestHandler.shutdown()
-    Await.ready(Registry.system.terminate(), Duration.Inf)
-    Await.ready(system.terminate(), Duration.Inf)
+    //Await.ready(Registry.system.terminate(), Duration.Inf)
+    //Await.ready(system.terminate(), Duration.Inf)
   }
 
   "The Server" should {


### PR DESCRIPTION
**Reason for this PR**
There is a race condition on Travis CI when executing the unit tests for the registry. For more information see #110.

**Changes in this PR**
- Removed unused ActorSystem from ```RequestHandlerTest```
- Removed explicit calls to ```system.shutdown()``` in ```ServerTest```

~~**Note**: I'm not sure if this solves the issue, there are only two CI builds for this fix yet, but both worked without the problem. I'll wait for the CI build on this PR and trigger some more builds (by adding whitespace or some similar) to see if the problems re-appears. Please **do not merge** for now!~~
There have been 15 successful CI builds on this code so far, so i would consider this solved. If the issue occurrs again, i will open a new issue for that.