### PR TITLE
Fixed a bug concerning link state updates

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -295,7 +295,7 @@ class RequestHandler(configuration: Configuration, authDao: AuthDAO, instanceDao
 
         deployResult match {
           case Failure(ex) =>
-            log.warning(s"Failed to deploy container, docker host not reachable.")
+            log.warning(s"Failed to deploy container, docker host not reachable. Message ${ex.getMessage}")
             instanceDao.removeInstance(id)
             fireDockerOperationErrorEvent(None, s"Deploy failed with message: ${ex.getMessage}")
             Failure(new RuntimeException(s"Failed to deploy container, docker host not reachable (${ex.getMessage})."))

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/daos/DatabaseInstanceDAO.scala
@@ -286,17 +286,18 @@ class DatabaseInstanceDAO (configuration : Configuration) extends InstanceDAO wi
   override def addLink(link: InstanceLink) : Try[Unit] = {
     if(hasInstance(link.idFrom) && hasInstance(link.idTo)){
 
+      //If new link is in state 'Assigned': Set any link that previously was assigned to 'outdated'
+      //IMPORTANT: Only works bc every component has exactly one dependency!
+      if(link.linkState == LinkState.Assigned){
+        for (prevLink <- getLinksFrom(link.idFrom, Some(LinkState.Assigned))){
+          updateLink(InstanceLink(prevLink.idFrom, prevLink.idTo, LinkState.Outdated))
+        }
+      }
+
       if(getLinksFrom(link.idFrom).exists(l => l.idTo == link.idTo)){
         //There already is a link between the two instances. Update it instead of adding a new one
         updateLink(link)
       } else {
-        //If new link is in state 'Assigned': Set any link that previously was assigned to 'outdated'
-        //IMPORTANT: Only works bc every component has exactly one dependency!
-        if(link.linkState == LinkState.Assigned){
-          for (prevLink <- getLinksFrom(link.idFrom, Some(LinkState.Assigned))){
-            updateLink(InstanceLink(prevLink.idFrom, prevLink.idTo, LinkState.Outdated))
-          }
-        }
         addLinkFromInstanceLink(link)
       }
       Success()


### PR DESCRIPTION
**Reason for this PR**
There was a bug that caused LinkStates to be invalid (two links in state ```Assigned``` for the same instance) when assigning new dependencies multiple times. See #113 for details.

**Changes in this PR**
Fixed link state updates to be consistent in both ```DynamicInstanceDAO``` and ```DatabaseInstanceDAO```.