### PR TITLE
An event is now being raised when labels are added

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/RequestHandler.scala
@@ -726,7 +726,9 @@ class RequestHandler(configuration: Configuration, authDao: AuthDAO, instanceDao
       OperationResult.IdUnknown
     } else {
       instanceDao.addLabelFor(id, label) match {
-        case Success(_) => OperationResult.Ok
+        case Success(_) =>
+          fireStateChangedEvent(instanceDao.getInstance(id).get)
+          OperationResult.Ok
         case Failure(_) => OperationResult.InternalError
       }
     }


### PR DESCRIPTION
**Reason for this PR**
The frontend was not able to display a newly added label for an instance without reloading the page, since now event was being raised for the operation. See #119 for details.

**Changes for this PR**
* An ```StateChangedEvent``` is now being raised when a label is added