### PR TITLE
Feature/change method for delete

### DIFF
--- a/OpenAPISpecification.yaml
+++ b/OpenAPISpecification.yaml
@@ -565,8 +565,8 @@ paths:
         '404':
           description: 'Not found, the id you specified could not be found'
 
-  '/instances/{Id}/label/{Label}':
-    delete:
+  '/instances/{Id}/label/{Label}/delete':
+    post:
       tags:
         - Basic Operations
       consumes:

--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -143,7 +143,7 @@ class Server(handler: RequestHandler) extends HttpApp
                 entity(as[JsValue]) { json => addLabel(Id, json.asJsObject) }
               }~
               pathPrefix(Segment) { label : String =>
-                pathEnd {
+                path("delete") {
                   removeLabel(Id, label)
                 }
               }
@@ -1013,7 +1013,7 @@ class Server(handler: RequestHandler) extends HttpApp
   def removeLabel(id: Long, label: String): server.Route = {
     authenticateOAuth2[AccessToken]("Secure Site", handler.authProvider.authenticateOAuthRequire(_, userType = UserType.Admin)) { token =>
 
-      delete {
+      post {
         handler.handleRemoveLabel(id, label) match {
           case handler.OperationResult.IdUnknown =>
             log.warning(s"Cannot remove label $label to $id, id not found.")

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -872,17 +872,17 @@ class ServerTest
     }
 
     "remove a label to an instance if label and id are valid" in {
-      Delete("/instances/0/label/Private") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
+      Post("/instances/0/label/Private/delete") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.OK)
       }
     }
 
     "fail to remove label if id is invalid or label does not exist" in {
-      Delete("/instances/22/label/Private") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
+      Post("/instances/22/label/Private/delete") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.NOT_FOUND)
       }
 
-      Delete("/instances/0/label/test") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
+      Post("/instances/0/label/test/delete") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.BAD_REQUEST)
       }
     }


### PR DESCRIPTION
Because of the request from front-end and maintaining the consistency I changed the DELETE method for label delete to POST 