### PR TITLE
Added a check to prevent users from deleting themselves

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instanceregistry/connection/Server.scala
@@ -1315,14 +1315,20 @@ class Server(handler: RequestHandler) extends HttpApp
 
       post {
         log.debug(s"POST /users/remove/$id has been called")
+
         try {
 
-          handler.handleRemoveUser(id) match {
-            case Success(_) =>
-              complete(HttpResponse(StatusCodes.Accepted, entity = "user successfully removed."))
-            case Failure(ex) =>
-              log.error(ex, "Failed to handle remove user.")
-              complete(HttpResponse(StatusCodes.BadRequest, entity = "User id does not exist."))
+          val callingUserId = Try(token.userId.toLong).getOrElse(-1)
+          if(callingUserId == id){
+              complete{HttpResponse(StatusCodes.BadRequest, entity = "Users cannot delete themselves.")}
+          } else {
+            handler.handleRemoveUser(id) match {
+               case Success(_) =>
+                 complete(HttpResponse(StatusCodes.Accepted, entity = "user successfully removed."))
+               case Failure(ex) =>
+                 log.error(ex, "Failed to handle remove user.")
+                 complete(HttpResponse(StatusCodes.BadRequest, entity = "User id does not exist."))
+            }
           }
         } catch {
           case dx: DeserializationException =>

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -257,6 +257,11 @@ class ServerTest
         assert(status === StatusCodes.UNAUTHORIZED)
       }
 
+      //Users cannot delete themselves
+      Post("/users/4/remove") ~> addAuthorization("Admin", "4") ~> Route.seal(server.routes) ~> check {
+        assert(status === StatusCodes.BAD_REQUEST)
+      }
+
       //should use valid request method
       Get("/users/4/remove") ~> addAuthorization("Admin") ~> Route.seal(server.routes) ~> check {
         assert(status === StatusCodes.METHOD_NOT_ALLOWED)
@@ -1048,18 +1053,18 @@ class ServerTest
     }
   }
 
-  private def generateValidTestToken(userType: String): String = {
+  private def generateValidTestToken(userType: String, id: String = "Server Unit Test"): String = {
     val claim = JwtClaim()
       .issuedNow
       .expiresIn(5)
       .startsNow
-      . + ("user_id", "Server Unit Test")
+      . + ("user_id", id)
       . + ("user_type", userType)
 
     Jwt.encode(claim, configuration.jwtSecretKey, JwtAlgorithm.HS256)
   }
 
-  private def addAuthorization(userType: String): HttpRequest => HttpRequest = addHeader(Authorization.oauth2(generateValidTestToken(userType)))
+  private def addAuthorization(userType: String, id: String = "Server Unit Test"): HttpRequest => HttpRequest = addHeader(Authorization.oauth2(generateValidTestToken(userType, id)))
 
   private def addBasicAuth(username: String, password: String): HttpRequest => HttpRequest = addHeader(Authorization.basic(username, password))
 }

--- a/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
+++ b/src/test/scala/de/upb/cs/swt/delphi/instanceregistry/connection/ServerTest.scala
@@ -1064,7 +1064,8 @@ class ServerTest
     Jwt.encode(claim, configuration.jwtSecretKey, JwtAlgorithm.HS256)
   }
 
-  private def addAuthorization(userType: String, id: String = "Server Unit Test"): HttpRequest => HttpRequest = addHeader(Authorization.oauth2(generateValidTestToken(userType, id)))
+  private def addAuthorization(userType: String, id: String = "Server Unit Test"): HttpRequest => HttpRequest =
+    addHeader(Authorization.oauth2(generateValidTestToken(userType, id)))
 
   private def addBasicAuth(username: String, password: String): HttpRequest => HttpRequest = addHeader(Authorization.basic(username, password))
 }


### PR DESCRIPTION
**Reason for this PR**
When deleting a user, the application does not validate which entity is executing the operation. This implies that users are able to delete themselves. If the last registered user deletes himself / herself, then the application is effectively bricked, meaning there is no way to login anymore.

**Changes in this PR**
Added a verification that will return BadRequest when users try to delete themselves. Added corresponding test case.